### PR TITLE
Add pagination to search results

### DIFF
--- a/frontend/client/components/SearchPagination.tsx
+++ b/frontend/client/components/SearchPagination.tsx
@@ -1,0 +1,193 @@
+import { cn } from "@/lib/utils";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface SearchPaginationProps {
+  currentPage: number;
+  totalPages: number;
+  pageSize: number;
+  totalCount: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
+  isLoading?: boolean;
+}
+
+export function SearchPagination({
+  currentPage,
+  totalPages,
+  pageSize,
+  totalCount,
+  onPageChange,
+  onPageSizeChange,
+  isLoading = false,
+}: SearchPaginationProps) {
+  const pageSizeOptions = [10, 25, 50, 100];
+
+  const getVisiblePages = () => {
+    const delta = 2; // Number of pages to show on each side of current page
+    const range = [];
+    const rangeWithDots = [];
+
+    for (
+      let i = Math.max(2, currentPage - delta);
+      i <= Math.min(totalPages - 1, currentPage + delta);
+      i++
+    ) {
+      range.push(i);
+    }
+
+    if (currentPage - delta > 2) {
+      rangeWithDots.push(1, "...");
+    } else {
+      rangeWithDots.push(1);
+    }
+
+    rangeWithDots.push(...range);
+
+    if (currentPage + delta < totalPages - 1) {
+      rangeWithDots.push("...", totalPages);
+    } else if (totalPages > 1) {
+      rangeWithDots.push(totalPages);
+    }
+
+    return rangeWithDots;
+  };
+
+  const visiblePages = getVisiblePages();
+  const startResult = (currentPage - 1) * pageSize + 1;
+  const endResult = Math.min(currentPage * pageSize, totalCount);
+
+  if (totalPages <= 1) {
+    return (
+      <div className="flex items-center justify-between gap-4 text-sm text-material-text-secondary">
+        <div className="flex items-center gap-2">
+          <span>Results per page:</span>
+          <Select
+            value={pageSize.toString()}
+            onValueChange={(value) => onPageSizeChange(parseInt(value))}
+            disabled={isLoading}
+          >
+            <SelectTrigger className="w-20 h-8 border-none border-b border-[rgba(0,0,0,0.42)] rounded-none bg-transparent focus:border-material-blue">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {pageSizeOptions.map((size) => (
+                <SelectItem key={size} value={size.toString()}>
+                  {size}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        {totalCount > 0 && (
+          <div>
+            Showing {startResult} to {endResult} of {totalCount} results
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+      {/* Results per page selector */}
+      <div className="flex items-center gap-2 text-sm text-material-text-secondary">
+        <span>Results per page:</span>
+        <Select
+          value={pageSize.toString()}
+          onValueChange={(value) => onPageSizeChange(parseInt(value))}
+          disabled={isLoading}
+        >
+          <SelectTrigger className="w-20 h-8 border-none border-b border-[rgba(0,0,0,0.42)] rounded-none bg-transparent focus:border-material-blue">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {pageSizeOptions.map((size) => (
+              <SelectItem key={size} value={size.toString()}>
+                {size}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Results info */}
+      <div className="text-sm text-material-text-secondary">
+        Showing {startResult} to {endResult} of {totalCount} results
+      </div>
+
+      {/* Pagination controls */}
+      <div className="flex items-center gap-1">
+        {/* Previous button */}
+        <button
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={currentPage === 1 || isLoading}
+          className={cn(
+            "flex items-center gap-1 px-3 py-1.5 text-sm font-medium transition-all duration-200 rounded",
+            "text-material-text-secondary hover:bg-material-surface",
+            "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent",
+          )}
+        >
+          <ChevronLeft className="w-4 h-4" />
+          <span className="hidden sm:inline">Previous</span>
+        </button>
+
+        {/* Page numbers */}
+        <div className="flex items-center gap-1">
+          {visiblePages.map((page, index) => {
+            if (page === "...") {
+              return (
+                <span
+                  key={`ellipsis-${index}`}
+                  className="px-2 py-1 text-sm text-material-text-secondary"
+                >
+                  ...
+                </span>
+              );
+            }
+
+            const pageNumber = page as number;
+            const isActive = pageNumber === currentPage;
+
+            return (
+              <button
+                key={pageNumber}
+                onClick={() => onPageChange(pageNumber)}
+                disabled={isLoading}
+                className={cn(
+                  "w-8 h-8 text-sm font-medium transition-all duration-200 rounded",
+                  isActive
+                    ? "bg-material-blue text-white shadow-[0px_1px_3px_0px_rgba(0,0,0,0.12),0px_1px_2px_0px_rgba(0,0,0,0.24)]"
+                    : "text-material-text-secondary hover:bg-material-surface",
+                  "disabled:opacity-50 disabled:cursor-not-allowed",
+                )}
+              >
+                {pageNumber}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Next button */}
+        <button
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={currentPage === totalPages || isLoading}
+          className={cn(
+            "flex items-center gap-1 px-3 py-1.5 text-sm font-medium transition-all duration-200 rounded",
+            "text-material-text-secondary hover:bg-material-surface",
+            "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent",
+          )}
+        >
+          <span className="hidden sm:inline">Next</span>
+          <ChevronRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/client/components/SearchPagination.tsx
+++ b/frontend/client/components/SearchPagination.tsx
@@ -63,35 +63,8 @@ export function SearchPagination({
   const startResult = (currentPage - 1) * pageSize + 1;
   const endResult = Math.min(currentPage * pageSize, totalCount);
 
-  if (totalPages <= 1) {
-    return (
-      <div className="flex items-center justify-between gap-4 text-sm text-material-text-secondary">
-        <div className="flex items-center gap-2">
-          <span>Results per page:</span>
-          <Select
-            value={pageSize.toString()}
-            onValueChange={(value) => onPageSizeChange(parseInt(value))}
-            disabled={isLoading}
-          >
-            <SelectTrigger className="w-20 h-8 border-none border-b border-[rgba(0,0,0,0.42)] rounded-none bg-transparent focus:border-material-blue">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {pageSizeOptions.map((size) => (
-                <SelectItem key={size} value={size.toString()}>
-                  {size}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        {totalCount > 0 && (
-          <div>
-            Showing {startResult} to {endResult} of {totalCount} results
-          </div>
-        )}
-      </div>
-    );
+  if (totalCount === 0) {
+    return null;
   }
 
   return (

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -17,13 +17,6 @@ export default function Search() {
     actions,
   } = useSearch();
 
-  // Trigger search when page or pageSize changes (but not on initial load)
-  useEffect(() => {
-    if (hasSearched) {
-      actions.performSearch();
-    }
-  }, [currentPage, pageSize]);
-
   // Placeholder data for dropdowns
   const years = ["2024", "2023", "2022", "2021", "2020", "2019"];
   const targets = [

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -1,10 +1,28 @@
 import { cn } from "@/lib/utils";
 import { Search as SearchIcon, Download, FileText } from "lucide-react";
 import { useSearch } from "@/hooks/use-search";
+import { SearchPagination } from "@/components/SearchPagination";
+import { useEffect } from "react";
 
 export default function Search() {
-  const { filters, isSearching, searchResults, hasSearched, actions } =
-    useSearch();
+  const {
+    filters,
+    isSearching,
+    searchResults,
+    hasSearched,
+    totalCount,
+    totalPages,
+    currentPage,
+    pageSize,
+    actions,
+  } = useSearch();
+
+  // Trigger search when page or pageSize changes (but not on initial load)
+  useEffect(() => {
+    if (hasSearched) {
+      actions.performSearch();
+    }
+  }, [currentPage, pageSize, hasSearched]);
 
   // Placeholder data for dropdowns
   const years = ["2024", "2023", "2022", "2021", "2020", "2019"];
@@ -199,7 +217,7 @@ export default function Search() {
         {/* Action Buttons */}
         <div className="flex items-center gap-4">
           <button
-            onClick={actions.performSearch}
+            onClick={() => actions.performSearch(true)}
             disabled={isSearching}
             className={cn(
               "flex items-center justify-center gap-2 px-6 py-3 rounded-md bg-material-blue text-white text-[15px] font-medium leading-[26px] tracking-[0.46px] uppercase transition-all duration-200",
@@ -230,18 +248,14 @@ export default function Search() {
 
         {/* Search Results */}
         {hasSearched && (
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-6">
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-medium text-material-text-primary">
                 Search Results
               </h2>
-              <span className="text-sm text-material-text-secondary">
-                {searchResults.length}{" "}
-                {searchResults.length === 1 ? "result" : "results"} found
-              </span>
             </div>
 
-            {searchResults.length === 0 ? (
+            {totalCount === 0 ? (
               <div className="text-center py-12 text-material-text-secondary">
                 <FileText className="w-12 h-12 mx-auto mb-4 opacity-50" />
                 <p>No clauses found matching your search criteria.</p>
@@ -250,73 +264,98 @@ export default function Search() {
                 </p>
               </div>
             ) : (
-              <div className="grid gap-4">
-                {searchResults.map((result) => (
-                  <div
-                    key={result.id}
-                    className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden"
-                  >
-                    {/* Header with metadata */}
-                    <div className="bg-gray-50 px-4 py-3 border-b border-gray-200">
-                      <div className="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm">
-                        <div>
-                          <span className="font-medium text-material-text-secondary">
-                            Year:
-                          </span>
-                          <div className="text-material-text-primary">
-                            {result.year}
-                          </div>
-                        </div>
-                        <div>
-                          <span className="font-medium text-material-text-secondary">
-                            Target:
-                          </span>
-                          <div className="text-material-text-primary">
-                            {result.target}
-                          </div>
-                        </div>
-                        <div>
-                          <span className="font-medium text-material-text-secondary">
-                            Acquirer:
-                          </span>
-                          <div className="text-material-text-primary">
-                            {result.acquirer}
-                          </div>
-                        </div>
-                        <div>
-                          <span className="font-medium text-material-text-secondary">
-                            Article:
-                          </span>
-                          <div className="text-material-text-primary">
-                            {result.articleTitle}
-                          </div>
-                        </div>
-                        <div>
-                          <span className="font-medium text-material-text-secondary">
-                            Section:
-                          </span>
-                          <div className="text-material-text-primary">
-                            {result.sectionTitle}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
+              <>
+                {/* Top pagination controls */}
+                <SearchPagination
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  pageSize={pageSize}
+                  totalCount={totalCount}
+                  onPageChange={actions.goToPage}
+                  onPageSizeChange={actions.changePageSize}
+                  isLoading={isSearching}
+                />
 
-                    {/* Clause text */}
-                    <div className="p-4">
-                      <div
-                        className="h-32 overflow-y-auto text-sm text-material-text-primary leading-relaxed"
-                        style={{
-                          scrollbarWidth: "thin",
-                          scrollbarColor: "#e5e7eb #f9fafb",
-                        }}
-                      >
-                        {result.xml}
+                {/* Results grid */}
+                <div className="grid gap-4">
+                  {searchResults.map((result) => (
+                    <div
+                      key={result.id}
+                      className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden"
+                    >
+                      {/* Header with metadata */}
+                      <div className="bg-gray-50 px-4 py-3 border-b border-gray-200">
+                        <div className="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm">
+                          <div>
+                            <span className="font-medium text-material-text-secondary">
+                              Year:
+                            </span>
+                            <div className="text-material-text-primary">
+                              {result.year}
+                            </div>
+                          </div>
+                          <div>
+                            <span className="font-medium text-material-text-secondary">
+                              Target:
+                            </span>
+                            <div className="text-material-text-primary">
+                              {result.target}
+                            </div>
+                          </div>
+                          <div>
+                            <span className="font-medium text-material-text-secondary">
+                              Acquirer:
+                            </span>
+                            <div className="text-material-text-primary">
+                              {result.acquirer}
+                            </div>
+                          </div>
+                          <div>
+                            <span className="font-medium text-material-text-secondary">
+                              Article:
+                            </span>
+                            <div className="text-material-text-primary">
+                              {result.articleTitle}
+                            </div>
+                          </div>
+                          <div>
+                            <span className="font-medium text-material-text-secondary">
+                              Section:
+                            </span>
+                            <div className="text-material-text-primary">
+                              {result.sectionTitle}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Clause text */}
+                      <div className="p-4">
+                        <div
+                          className="h-32 overflow-y-auto text-sm text-material-text-primary leading-relaxed"
+                          style={{
+                            scrollbarWidth: "thin",
+                            scrollbarColor: "#e5e7eb #f9fafb",
+                          }}
+                        >
+                          {result.xml}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
+
+                {/* Bottom pagination controls */}
+                <SearchPagination
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  pageSize={pageSize}
+                  totalCount={totalCount}
+                  onPageChange={actions.goToPage}
+                  onPageSizeChange={actions.changePageSize}
+                  isLoading={isSearching}
+                />
+              </>
             )}
           </div>
         )}

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -22,7 +22,7 @@ export default function Search() {
     if (hasSearched) {
       actions.performSearch();
     }
-  }, [currentPage, pageSize, hasSearched]);
+  }, [currentPage, pageSize]);
 
   // Placeholder data for dropdowns
   const years = ["2024", "2023", "2022", "2021", "2020", "2019"];

--- a/frontend/shared/search.ts
+++ b/frontend/shared/search.ts
@@ -5,6 +5,8 @@ export interface SearchFilters {
   target?: string;
   acquirer?: string;
   clauseType?: string;
+  page?: number;
+  pageSize?: number;
 }
 
 export interface SearchResult {
@@ -24,6 +26,7 @@ export interface SearchResponse {
   totalCount: number;
   page: number;
   pageSize: number;
+  totalPages: number;
 }
 
 // Filter options (to be populated from API)


### PR DESCRIPTION
This change adds pagination functionality to the search results page.

Changes made:
- Created new SearchPagination component with page navigation controls
- Added page size selector with options for 10, 25, 50, 100 results per page
- Updated useSearch hook to handle pagination state (page, pageSize, totalCount, totalPages)
- Modified search API calls to include pagination parameters
- Added pagination controls above and below search results
- Updated SearchFilters and SearchResponse interfaces to include pagination fields
- Added useEffect to trigger search when page or pageSize changes

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d20297099941410ea76f12573adde4c2/aura-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d20297099941410ea76f12573adde4c2</projectId>-->
<!--<branchName>aura-haven</branchName>-->