### PR TITLE
Add error and no results modals to search functionality

### DIFF
--- a/frontend/client/components/InfoModal.tsx
+++ b/frontend/client/components/InfoModal.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib/utils";
+import { Info, X } from "lucide-react";
+
+interface InfoModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  message: string;
+}
+
+export default function InfoModal({
+  isOpen,
+  onClose,
+  title = "Information",
+  message,
+}: InfoModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black bg-opacity-50"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative bg-white rounded-lg shadow-xl w-full max-w-md mx-4">
+        {/* Header */}
+        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+          <div className="flex items-center gap-3">
+            <Info className="w-6 h-6 text-material-blue" />
+            <h3 className="text-lg font-medium text-material-text-primary">
+              {title}
+            </h3>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6">
+          <p className="text-material-text-secondary">{message}</p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-end gap-3 p-6 border-t border-gray-200">
+          <button
+            onClick={onClose}
+            className={cn(
+              "px-4 py-2 text-sm font-medium text-white bg-material-blue rounded-md transition-colors",
+              "hover:bg-blue-700 focus:ring-2 focus:ring-material-blue focus:ring-offset-2",
+            )}
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -315,6 +315,13 @@ export function useLLMOutput() {
     });
   }, [updateState]);
 
+  const closeInfoModal = useCallback(() => {
+    updateState({
+      showInfoModal: false,
+      infoMessage: "",
+    });
+  }, [updateState]);
+
   return {
     state,
     actions: {
@@ -330,6 +337,7 @@ export function useLLMOutput() {
       updatePageUuid,
       updateLLMOutput,
       closeErrorModal,
+      closeInfoModal,
     },
   };
 }

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -16,6 +16,8 @@ export interface LLMOutputState {
   showSaveConfirmation: boolean;
   showErrorModal: boolean;
   errorMessage: string;
+  showInfoModal: boolean;
+  infoMessage: string;
 }
 
 export function useLLMOutput() {

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -37,6 +37,8 @@ export function useLLMOutput() {
     showSaveConfirmation: false,
     showErrorModal: false,
     errorMessage: "",
+    showInfoModal: false,
+    infoMessage: "",
   });
 
   // Load settings from localStorage on mount

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -103,10 +103,10 @@ export function useLLMOutput() {
       // Check if the response is ok (status 200-299)
       if (!res.ok) {
         if (res.status === 404) {
-          // UUID not found in database
+          // UUID not found in database - this is informational, not an error
           updateState({
-            showErrorModal: true,
-            errorMessage: "No page with that UUID exists in mna.llm_output.",
+            showInfoModal: true,
+            infoMessage: "No page with that UUID exists in mna.llm_output.",
           });
           return;
         }
@@ -119,8 +119,8 @@ export function useLLMOutput() {
       // Check if the response data is empty or null
       if (!responseData || Object.keys(responseData).length === 0) {
         updateState({
-          showErrorModal: true,
-          errorMessage: "No page with that UUID exists in mna.llm_output.",
+          showInfoModal: true,
+          infoMessage: "No page with that UUID exists in mna.llm_output.",
         });
         return;
       }

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -228,6 +228,15 @@ export function useSearch() {
     [allResults],
   );
 
+  const closeErrorModal = useCallback(() => {
+    setShowErrorModal(false);
+    setErrorMessage("");
+  }, []);
+
+  const closeNoResultsModal = useCallback(() => {
+    setShowNoResultsModal(false);
+  }, []);
+
   return {
     filters,
     isSearching,
@@ -237,6 +246,9 @@ export function useSearch() {
     totalPages,
     currentPage: filters.page || 1,
     pageSize: filters.pageSize || 25,
+    showErrorModal,
+    errorMessage,
+    showNoResultsModal,
     actions: {
       updateFilter,
       performSearch,
@@ -244,6 +256,8 @@ export function useSearch() {
       clearFilters,
       goToPage,
       changePageSize,
+      closeErrorModal,
+      closeNoResultsModal,
     },
   };
 }

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -17,6 +17,9 @@ export function useSearch() {
   const [hasSearched, setHasSearched] = useState(false);
   const [totalCount, setTotalCount] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
+  const [showErrorModal, setShowErrorModal] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [showNoResultsModal, setShowNoResultsModal] = useState(false);
 
   const updateFilter = useCallback(
     (field: keyof SearchFilters, value: string) => {

--- a/frontend/client/pages/Edit.tsx
+++ b/frontend/client/pages/Edit.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import SaveConfirmationModal from "@/components/SaveConfirmationModal";
 import ErrorModal from "@/components/ErrorModal";
+import InfoModal from "@/components/InfoModal";
 
 export default function Index() {
   const { state, actions } = useLLMOutput();

--- a/frontend/client/pages/Edit.tsx
+++ b/frontend/client/pages/Edit.tsx
@@ -206,6 +206,14 @@ export default function Index() {
         onClose={actions.closeErrorModal}
         message={state.errorMessage}
       />
+
+      {/* Info Modal */}
+      <InfoModal
+        isOpen={state.showInfoModal}
+        onClose={actions.closeInfoModal}
+        title="Page Not Found"
+        message={state.infoMessage}
+      />
     </div>
   );
 }

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -15,6 +15,9 @@ export default function Search() {
     totalPages,
     currentPage,
     pageSize,
+    showErrorModal,
+    errorMessage,
+    showNoResultsModal,
     actions,
   } = useSearch();
 

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/lib/utils";
 import { Search as SearchIcon, Download, FileText } from "lucide-react";
 import { useSearch } from "@/hooks/use-search";
 import { SearchPagination } from "@/components/SearchPagination";
+import ErrorModal from "@/components/ErrorModal";
 import { useEffect } from "react";
 
 export default function Search() {

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -357,6 +357,21 @@ export default function Search() {
           </div>
         )}
       </div>
+
+      {/* Backend Connection Error Modal */}
+      <ErrorModal
+        isOpen={showErrorModal}
+        onClose={actions.closeErrorModal}
+        message={errorMessage}
+      />
+
+      {/* No Results Modal */}
+      <ErrorModal
+        isOpen={showNoResultsModal}
+        onClose={actions.closeNoResultsModal}
+        title="No Results Found"
+        message="No results to display given the selected filters."
+      />
     </div>
   );
 }

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -366,8 +366,8 @@ export default function Search() {
         message={errorMessage}
       />
 
-      {/* No Results Modal */}
-      <ErrorModal
+      {/* No Results Info Modal */}
+      <InfoModal
         isOpen={showNoResultsModal}
         onClose={actions.closeNoResultsModal}
         title="No Results Found"

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -3,6 +3,7 @@ import { Search as SearchIcon, Download, FileText } from "lucide-react";
 import { useSearch } from "@/hooks/use-search";
 import { SearchPagination } from "@/components/SearchPagination";
 import ErrorModal from "@/components/ErrorModal";
+import InfoModal from "@/components/InfoModal";
 import { useEffect } from "react";
 
 export default function Search() {


### PR DESCRIPTION
This change adds modal dialogs to handle error states and empty search results in the search functionality.

Changes made:
- Added three new state variables to useSearch hook: showErrorModal, errorMessage, and showNoResultsModal
- Added error handling in performSearch to show network error modal when fetch fails
- Added logic to show no results modal when search returns empty results with active filters
- Added helper function hasFiltersApplied to check if any search filters are active
- Added closeErrorModal and closeNoResultsModal callback functions
- Updated useSearch return object to expose new modal states and close functions
- Added two ErrorModal components to Search.tsx for displaying error and no results messages
- Reset modal states at the beginning of each search operation

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d20297099941410ea76f12573adde4c2/echo-verse)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d20297099941410ea76f12573adde4c2</projectId>-->
<!--<branchName>echo-verse</branchName>-->