### PR TITLE
Add standardId extraction from clause types in search

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,7 +2,7 @@ import os
 from flask import Flask, jsonify, request, abort
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy import create_engine, MetaData, Table, func, desc, Column, CHAR, TEXT, Table
+from sqlalchemy import create_engine, MetaData, Table, func, desc, Column, CHAR, TEXT, Table, text
 from sqlalchemy.dialects.mysql import LONGTEXT, TINYTEXT
 
 # ── Flask setup ──────────────────────────────────────────────────────────
@@ -165,12 +165,12 @@ def get_filter_options():
     try:
         # Execute the SQL query to get distinct targets and acquirers
         result = db.session.execute(
-            """
+            text("""
             SELECT DISTINCT target, acquirer
             FROM mna.agreements a
             JOIN mna.xml x ON a.uuid = x.agreement_uuid
             ORDER BY target, acquirer
-            """
+            """)
         ).fetchall()
 
         # Extract unique targets and acquirers

--- a/backend/app.py
+++ b/backend/app.py
@@ -81,8 +81,8 @@ class Agreements(db.Model):
 
 class XML(db.Model):
     __table__ = xml_table
-    
-    
+
+
 class Taxonomy(db.Model):
     __table__ = taxonomy_table
 
@@ -155,6 +155,33 @@ def get_agreement(agreement_uuid):
         "url":      url,
         "xml":      xml_content
     })
+
+
+@app.route("/api/filter-options", methods=["GET"])
+def get_filter_options():
+    """Fetch distinct targets and acquirers from the database"""
+    try:
+        # Execute the SQL query to get distinct targets and acquirers
+        result = db.session.execute(
+            """
+            SELECT DISTINCT target, acquirer
+            FROM mna.agreements a
+            JOIN mna.xml x ON a.uuid = x.agreement_uuid
+            ORDER BY target, acquirer
+            """
+        ).fetchall()
+
+        # Extract unique targets and acquirers
+        targets = sorted(set(row[0] for row in result if row[0]))
+        acquirers = sorted(set(row[1] for row in result if row[1]))
+
+        return jsonify({
+            "targets": targets,
+            "acquirers": acquirers
+        }), 200
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 
 @app.route("/api/search", methods=["GET"])

--- a/frontend/client/hooks/use-filter-options.ts
+++ b/frontend/client/hooks/use-filter-options.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect } from "react";
+import { FilterOptionsResponse } from "@shared/search";
+
+interface UseFilterOptionsReturn {
+  targets: string[];
+  acquirers: string[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useFilterOptions(): UseFilterOptionsReturn {
+  const [targets, setTargets] = useState<string[]>([]);
+  const [acquirers, setAcquirers] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Check if we already have cached data in sessionStorage
+    const cachedData = sessionStorage.getItem("filterOptions");
+    if (cachedData) {
+      try {
+        const parsed: FilterOptionsResponse = JSON.parse(cachedData);
+        setTargets(parsed.targets || []);
+        setAcquirers(parsed.acquirers || []);
+        setIsLoading(false);
+        return;
+      } catch (e) {
+        // If parsing fails, continue to fetch from API
+        sessionStorage.removeItem("filterOptions");
+      }
+    }
+
+    // Fetch from API
+    const fetchFilterOptions = async () => {
+      try {
+        const response = await fetch(
+          "http://127.0.0.1:5000/api/filter-options",
+        );
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        const data: FilterOptionsResponse = await response.json();
+
+        // Update state
+        setTargets(data.targets || []);
+        setAcquirers(data.acquirers || []);
+
+        // Cache in sessionStorage for future use
+        sessionStorage.setItem("filterOptions", JSON.stringify(data));
+
+        setError(null);
+      } catch (err) {
+        console.error("Failed to fetch filter options:", err);
+        setError(
+          err instanceof Error ? err.message : "Failed to fetch filter options",
+        );
+
+        // Fallback to empty arrays
+        setTargets([]);
+        setAcquirers([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchFilterOptions();
+  }, []);
+
+  return {
+    targets,
+    acquirers,
+    isLoading,
+    error,
+  };
+}

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -260,6 +260,7 @@ export function useSearch() {
       target: [],
       acquirer: [],
       clauseType: [],
+      standardId: [],
       page: 1,
       pageSize: 25,
     });

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -1,6 +1,31 @@
 import { useState, useCallback } from "react";
 import { SearchFilters, SearchResult, SearchResponse } from "@shared/search";
 
+// Function to extract standard IDs from nested clause type structure
+const extractStandardIds = (
+  clauseTypeTexts: string[],
+  clauseTypesNested: any,
+): string[] => {
+  const standardIds: string[] = [];
+
+  const searchInNested = (obj: any): void => {
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === "string") {
+        // This is a leaf node - check if the key matches any selected clause type
+        if (clauseTypeTexts.includes(key)) {
+          standardIds.push(value as string);
+        }
+      } else if (typeof value === "object") {
+        // Recurse into nested object
+        searchInNested(value);
+      }
+    }
+  };
+
+  searchInNested(clauseTypesNested);
+  return standardIds;
+};
+
 export function useSearch() {
   const [filters, setFilters] = useState<SearchFilters>({
     year: [],

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -7,6 +7,7 @@ export function useSearch() {
     target: [],
     acquirer: [],
     clauseType: [],
+    standardId: [],
     page: 1,
     pageSize: 25,
   });

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -74,7 +74,7 @@ export function useSearch() {
   );
 
   const performSearch = useCallback(
-    async (resetPage = false) => {
+    async (resetPage = false, clauseTypesNested?: any) => {
       setIsSearching(true);
       setShowErrorModal(false);
       setShowNoResultsModal(false);
@@ -105,9 +105,19 @@ export function useSearch() {
             params.append("acquirer", acquirer),
           );
         }
-        if (searchFilters.clauseType && searchFilters.clauseType.length > 0) {
-          searchFilters.clauseType.forEach((clauseType) =>
-            params.append("clauseType", clauseType),
+
+        // Extract standard IDs from selected clause types and send them instead
+        if (
+          searchFilters.clauseType &&
+          searchFilters.clauseType.length > 0 &&
+          clauseTypesNested
+        ) {
+          const standardIds = extractStandardIds(
+            searchFilters.clauseType,
+            clauseTypesNested,
+          );
+          standardIds.forEach((standardId) =>
+            params.append("standardId", standardId),
           );
         }
 

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -98,249 +98,264 @@ export default function Search() {
   ];
 
   const clauseTypesNested = {
-  "Conditions, Termination & Closing": {
-    "Closing Conditions": {
-      "Conditions to Closing \u2013 Mutual or Each Party": "0d3d3806dc32e929",
-      "Conditions to Closing \u2013 Party Specific": "27f3e7771de2bfc4"
+    "Conditions, Termination & Closing": {
+      "Closing Conditions": {
+        "Conditions to Closing \u2013 Mutual or Each Party": "0d3d3806dc32e929",
+        "Conditions to Closing \u2013 Party Specific": "27f3e7771de2bfc4",
+      },
+      "Closing Mechanics": {
+        "Accountant Consents & Comfort Letters": "ba6016031fc0754d",
+        "Appraisal / Dissenters' Rights": "452d682a4fa9b1dc",
+        "Asset Purchase Mechanics": "18bc2f6f399f1fe5",
+        "Basic Merger Mechanics": "7bc3272aa3b778e7",
+        "Closing Deliverables": "56be5748315e41d0",
+        "Effective Time; Closing Filings": "e66e3d365e3b3156",
+        "Effects of the Merger": "d7f5778a35a8dac6",
+        "Exchange & Payment Mechanics (Share Surrender)": "3f0f0f021e26686a",
+        "Offer; Tender Procedures": "655641a8ddf0a5e3",
+        "Shareholder & Stockholder Meetings": "468ae85912916eca",
+        "Stock Purchase Mechanics": "bb235fc028d4b0ff",
+        "Top-Up Options & Short-Form Merger Provisions": "0495fdd6552c9122",
+      },
+      "Termination Rights & Fees": {
+        "Termination Effects": "787011023387144e",
+        "Termination Fees & Break-Up Fees": "5d80283576bffb71",
+        "Termination Rights & Triggers": "b02f7059318d484d",
+      },
     },
-    "Closing Mechanics": {
-      "Accountant Consents & Comfort Letters": "ba6016031fc0754d",
-      "Appraisal / Dissenters' Rights": "452d682a4fa9b1dc",
-      "Asset Purchase Mechanics": "18bc2f6f399f1fe5",
-      "Basic Merger Mechanics": "7bc3272aa3b778e7",
-      "Closing Deliverables": "56be5748315e41d0",
-      "Effective Time; Closing Filings": "e66e3d365e3b3156",
-      "Effects of the Merger": "d7f5778a35a8dac6",
-      "Exchange & Payment Mechanics (Share Surrender)": "3f0f0f021e26686a",
-      "Offer; Tender Procedures": "655641a8ddf0a5e3",
-      "Shareholder & Stockholder Meetings": "468ae85912916eca",
-      "Stock Purchase Mechanics": "bb235fc028d4b0ff",
-      "Top-Up Options & Short-Form Merger Provisions": "0495fdd6552c9122"
+    "Consideration & Economics": {
+      "Assumption of Liabilities": {
+        "Assumed Liabilities": "4c2aa4862b6dc6ef",
+      },
+      "Purchase Price & Adjustments": {
+        "Contingent Value Rights (CVR) & Earn-Out Agreements":
+          "753cece4c610bcc3",
+        Distributions: "17a1631998eb3cef",
+        "Fairness Opinions & Financial Advisors": "d7ae412fdcc9d956",
+        "Purchase Price and Post-Closing Adjustments": "2b4119d25d6309ee",
+      },
+      "Stock & Equity Consideration": {
+        "Hook Stock & Treasury Shares": "84bfd0173448dd4d",
+        "Stock Issuance & Reservation": "2014181a8401598b",
+      },
     },
-    "Termination Rights & Fees": {
-      "Termination Effects": "787011023387144e",
-      "Termination Fees & Break-Up Fees": "5d80283576bffb71",
-      "Termination Rights & Triggers": "b02f7059318d484d"
-    }
-  },
-  "Consideration & Economics": {
-    "Assumption of Liabilities": {
-      "Assumed Liabilities": "4c2aa4862b6dc6ef"
+    Covenants: {
+      "Disclosure Schedule Interpretation": {
+        "Disclosure Schedule Interpretation & Cross-References":
+          "12778ed5811cb2c7",
+      },
+      "Interim Covenants": {
+        "Access to Information / Inspection Rights": "878cd2cffec068a3",
+        "Disclosure Schedule Updates & Notice of Certain Events":
+          "f1b8333aee3d87e6",
+        "Interim Operating Covenants & Forbearances": "a152d97ffdd63fd7",
+        "Merger Sub Covenants": "d5bb9a0288084408",
+        "Multiple Seller Coordination & Relationship Provisions":
+          "5052442de8422063",
+        "No-Shop / Non-Solicitation Covenants": "ed56961095cffa4c",
+        "Pre-Closing Reorganization & Structure Steps": "d00a3fc743aab08f",
+        "Reasonable Best Efforts; Cooperation": "d709883fed7af17c",
+        "Restrictive Covenants (Non-Competition / Non-Solicitation)":
+          "dc4f5d9952565c02",
+        "Transfer Restrictions & Lock-Up": "3cbbb51dc2926305",
+      },
+      "Post-Closing Covenants": {
+        "Further Assurances & Post-Closing Cooperation": "27ef2efa0f3398f1",
+        "Integration Planning & Transitional Matters": "94f771fc4289b31a",
+        "Miscellaneous Covenants": "821c9acdcc7ad1a7",
+        "Transition Services": "b5fddac82e36c386",
+        "Use of Name & Trademark Covenants": "5a7fae57519678c3",
+      },
     },
-    "Purchase Price & Adjustments": {
-      "Contingent Value Rights (CVR) & Earn-Out Agreements": "753cece4c610bcc3",
-      "Distributions": "17a1631998eb3cef",
-      "Fairness Opinions & Financial Advisors": "d7ae412fdcc9d956",
-      "Purchase Price and Post-Closing Adjustments": "2b4119d25d6309ee"
+    "Employment & Benefits": {
+      "Employee Matters": {
+        "Equity Awards, Stock Options & Company Benefit Equity":
+          "1b02124b75bc10c4",
+        "Labor, Employment & Employee Benefit Plans": "c773fe515c18494a",
+      },
     },
-    "Stock & Equity Consideration": {
-      "Hook Stock & Treasury Shares": "84bfd0173448dd4d",
-      "Stock Issuance & Reservation": "2014181a8401598b"
-    }
-  },
-  "Covenants": {
-    "Disclosure Schedule Interpretation": {
-      "Disclosure Schedule Interpretation & Cross-References": "12778ed5811cb2c7"
+    "Financing & Funding": {
+      "Debt & Instruments": {
+        "Debt Instruments and Financing Arrangements": "5941cf1b1a2f1063",
+        "Derivatives & Hedging Arrangements": "c92c796e9c6d19f0",
+      },
+      "Financing Commitments & Ability": {
+        "Financing Ability / Funds Availability": "0f9291f14f678472",
+        "Financing Source Provisions & Waivers": "3e1b582e2f9cc125",
+        "Parent/Holdco Guarantees": "6d0c8ff46e9aafe0",
+      },
+      "Financing Covenants": {
+        "Financing Cooperation & Support Covenants": "cb4ab225a7e5e348",
+      },
     },
-    "Interim Covenants": {
-      "Access to Information / Inspection Rights": "878cd2cffec068a3",
-      "Disclosure Schedule Updates & Notice of Certain Events": "f1b8333aee3d87e6",
-      "Interim Operating Covenants & Forbearances": "a152d97ffdd63fd7",
-      "Merger Sub Covenants": "d5bb9a0288084408",
-      "Multiple Seller Coordination & Relationship Provisions": "5052442de8422063",
-      "No-Shop / Non-Solicitation Covenants": "ed56961095cffa4c",
-      "Pre-Closing Reorganization & Structure Steps": "d00a3fc743aab08f",
-      "Reasonable Best Efforts; Cooperation": "d709883fed7af17c",
-      "Restrictive Covenants (Non-Competition / Non-Solicitation)": "dc4f5d9952565c02",
-      "Transfer Restrictions & Lock-Up": "3cbbb51dc2926305"
+    "General Provisions": {
+      "Boilerplate & Construction": {
+        "Alternative Transaction Structure / Change of Method":
+          "7dbd17612e9dabe5",
+        "Amendments; Extensions; Waivers": "c20cd24a0d84ba56",
+        "Arbitration & Dispute Resolution": "f383ecddb78f002f",
+        "Assignment & Successors": "305bb88f1e98b4d4",
+        Confidentiality: "6df8bc88edff7e3d",
+        "Counterparts & Electronic Signatures": "d44006cdbbb8ad0c",
+        "Entire Agreement": "10cd17a4560a7a7d",
+        "Governing Law; Jurisdiction; Jury Trial": "b79e1996d2f7bcac",
+        "Language & Translation": "6b403871d6bd4b42",
+        "No Third Party Beneficiaries": "f4591e658883f659",
+        "Notices & Communications": "40bba1e9ee7e2325",
+        "Relationship of the Parties; Independent Contractor Status":
+          "89a01278af3a9a40",
+        "Remedies; Specific Performance": "5b8b1666661c6c43",
+        "Service of Process": "433ef1632fe94c19",
+        "Severability and Boilerplate Provisions": "2560701d69ecbaff",
+      },
+      Definitions: {
+        "Definitions & Interpretation": "beee4c5deefdc2d0",
+      },
+      "Expenses & Advisors": {
+        "Brokers & Finders Fees": "da24cbb98240a799",
+        "Fees and Expenses": "a7227a5a1e16bdbb",
+      },
     },
-    "Post-Closing Covenants": {
-      "Further Assurances & Post-Closing Cooperation": "27ef2efa0f3398f1",
-      "Integration Planning & Transitional Matters": "94f771fc4289b31a",
-      "Miscellaneous Covenants": "821c9acdcc7ad1a7",
-      "Transition Services": "b5fddac82e36c386",
-      "Use of Name & Trademark Covenants": "5a7fae57519678c3"
-    }
-  },
-  "Employment & Benefits": {
-    "Employee Matters": {
-      "Equity Awards, Stock Options & Company Benefit Equity": "1b02124b75bc10c4",
-      "Labor, Employment & Employee Benefit Plans": "c773fe515c18494a"
-    }
-  },
-  "Financing & Funding": {
-    "Debt & Instruments": {
-      "Debt Instruments and Financing Arrangements": "5941cf1b1a2f1063",
-      "Derivatives & Hedging Arrangements": "c92c796e9c6d19f0"
+    "Governance & Shareholder Matters": {
+      "Board & Committees": {
+        "Board Approval & Recommendation": "77d8c1b6c3edaa15",
+        "Conflicts Committee Matters": "098f9d5c048af2ae",
+      },
+      "Post-Merger Governance": {
+        "Directors, Officers & Governance of Surviving Entity":
+          "e38fc136fafbd07b",
+      },
+      "Shareholder Agreements & Voting": {
+        "Securityholder Representative Provisions": "8766fbc645223b7d",
+        "Voting, Support & Shareholder Agreements": "dccc050c7b770819",
+      },
+      "Takeover & Anti-Takeover": {
+        "Antitakeover / Takeover Statutes": "9dacfb2c929bbd9a",
+        "UK Takeover Panel Matters": "fc39027ced6e9b5e",
+      },
     },
-    "Financing Commitments & Ability": {
-      "Financing Ability / Funds Availability": "0f9291f14f678472",
-      "Financing Source Provisions & Waivers": "3e1b582e2f9cc125",
-      "Parent/Holdco Guarantees": "6d0c8ff46e9aafe0"
+    "Indemnification & Liability": {
+      "Indemnification Mechanics": {
+        "Indemnifiable Losses Definition": "c76c574a8f437a05",
+        "Indemnification Escrow & Holdback Provisions": "726b4f89306e679a",
+        "Indemnification Limitations (Caps & Baskets)": "a73e0398ad8b0104",
+        "Indemnification Procedures": "9613f111a9bf9db6",
+      },
+      Indemnities: {
+        "Indemnification by Purchaser / Buyer": "b8ad9d98fefc6844",
+        "Indemnification by Seller / Target": "3f4a09babc73019c",
+      },
+      "Survival & Recourse": {
+        "D&O Indemnification & Insurance": "10866d4d64fc32c8",
+        "Indemnification \u2013 Exclusive Remedy / Sole Remedy":
+          "0fefebbe62102092",
+        "Non-Recourse & Limited Liability": "8718c336dc859307",
+        "Seller Releases & Waivers": "d7ce59cfd33e134d",
+        "Survival / Non-Survival of Reps & Warranties": "949a439a8c96ba76",
+      },
     },
-    "Financing Covenants": {
-      "Financing Cooperation & Support Covenants": "cb4ab225a7e5e348"
-    }
-  },
-  "General Provisions": {
-    "Boilerplate & Construction": {
-      "Alternative Transaction Structure / Change of Method": "7dbd17612e9dabe5",
-      "Amendments; Extensions; Waivers": "c20cd24a0d84ba56",
-      "Arbitration & Dispute Resolution": "f383ecddb78f002f",
-      "Assignment & Successors": "305bb88f1e98b4d4",
-      "Confidentiality": "6df8bc88edff7e3d",
-      "Counterparts & Electronic Signatures": "d44006cdbbb8ad0c",
-      "Entire Agreement": "10cd17a4560a7a7d",
-      "Governing Law; Jurisdiction; Jury Trial": "b79e1996d2f7bcac",
-      "Language & Translation": "6b403871d6bd4b42",
-      "No Third Party Beneficiaries": "f4591e658883f659",
-      "Notices & Communications": "40bba1e9ee7e2325",
-      "Relationship of the Parties; Independent Contractor Status": "89a01278af3a9a40",
-      "Remedies; Specific Performance": "5b8b1666661c6c43",
-      "Service of Process": "433ef1632fe94c19",
-      "Severability and Boilerplate Provisions": "2560701d69ecbaff"
+    "Regulatory & Compliance": {
+      "Antitrust & Competition": {
+        "Antitrust & Competition Filings": "3dd07ef88fe2d06c",
+      },
+      "Government Approvals": {
+        "Governmental Approvals & Consents": "5736fd3809ff8d95",
+      },
+      "Insider Trading & Section 16": {
+        "Section 16 & Insider Trading Compliance (incl. Rule 16b-3)":
+          "2ef0d8d1ce1c1a8f",
+      },
+      "Securities Filings & Disclosure": {
+        "Proxy Statement, Prospectus & Registration Matters":
+          "0fd42cc616dfd56b",
+        "Public Disclosure, Press Releases & SEC Communications":
+          "2d33954063e3ae0e",
+        "Securities Documents & Capital Markets Filings": "7fcc5649a3985190",
+      },
+      "Stock Exchange": {
+        "Stock Exchange Listing": "52748f62ccff7015",
+      },
     },
-    "Definitions": {
-      "Definitions & Interpretation": "beee4c5deefdc2d0"
+    "Representations & Warranties": {
+      "Assets & Liabilities": {
+        "Accounts Receivable & Accounts Payable": "bf3939f8db1cdb5c",
+        "Assets; Inventory & Goodwill": "4c49669ab3e2a089",
+        "Casualty Loss and Condemnation": "ee49e752cab4d692",
+        "Deposits & Deposit Liabilities (Banking)": "d429b02c43f3f808",
+        "Excluded Assets": "8f15d7260c5376bf",
+        "Loan Portfolio & Asset Quality": "9f853034983a9a6a",
+        "Real Property & Tangible Assets": "93314630278e3f4d",
+        "Undisclosed Liabilities": "3589284e71431996",
+      },
+      "Books & Records": {
+        "Books & Records": "842de2d70fbf1443",
+      },
+      "Capital Structure": {
+        Capitalization: "2091c8e1a4d26971",
+        "Stock Ownership Representations": "06b871f2e90569f1",
+      },
+      "Changes & Updates": {
+        "Absence of Certain Changes / Events": "ede429a629cd3b41",
+      },
+      "Contracts & Relationships": {
+        "Customers & Suppliers; Business Relationships": "7233d89a27c42583",
+        "Material Contracts & Commitments": "330d438a248a3d42",
+        "Related Party Transactions": "31ca3ad3458e621c",
+      },
+      "Corporate Organization & Authority": {
+        "Authority & Non-Contravention": "ae87408e3761beb1",
+        "Charter & Bylaws of Surviving Entity": "770417d31342dfdd",
+        "General / Introductory Representations & Warranties":
+          "ab254c22aefab482",
+        "Merger Sub Representations": "431556a5a84f90cf",
+        "Organizational Matters (Existence, Qualification, Subsidiaries)":
+          "206b2da0fb295d63",
+        "Solvency Representations": "914f006e880c9b38",
+      },
+      "Disclosure & Accuracy": {
+        "Disclaimer of Other Representations": "a41fcf985e05fab1",
+        "Disclosure; Accuracy of Information": "921ae6080f3d21a9",
+      },
+      "Financial Information & Controls": {
+        "Financial Projections & Forecasts": "60bc1d30739af1fd",
+        "Financial Statements & Accounting": "8516ebe5cd9bd0da",
+        "Interim Financial Information": "d202d93d2dd353f1",
+        "Internal Controls & Sarbanes-Oxley Compliance": "4f1df8f12a4b5a3d",
+      },
+      "Insurance & Warranty": {
+        "Insurance Matters": "b6a4646b170e7a10",
+        "Product Warranty & Liability": "10ac69129ed22eb0",
+      },
+      "Intellectual Property": {
+        "Intellectual Property": "2ba0f1c7aea9472c",
+      },
+      "Litigation & Disputes": {
+        "Litigation & Legal Proceedings": "662bf7d543cdddcf",
+        "Shareholder & Securityholder Litigation": "db6a86b940dd8b4f",
+      },
+      "Operational Compliance & Permits": {
+        "Anti-Corruption & FCPA Compliance": "9fe92383900ee52e",
+        "Compliance with Laws and Regulatory Matters": "d0a4735e95f26ac9",
+        "Data Privacy & Cybersecurity": "f39f22b4fcc6f60d",
+        "Environmental Matters": "8edf005cfab27fe0",
+        "Permits & Franchises": "e8e20e5fda2cbbda",
+      },
     },
-    "Expenses & Advisors": {
-      "Brokers & Finders Fees": "da24cbb98240a799",
-      "Fees and Expenses": "a7227a5a1e16bdbb"
-    }
-  },
-  "Governance & Shareholder Matters": {
-    "Board & Committees": {
-      "Board Approval & Recommendation": "77d8c1b6c3edaa15",
-      "Conflicts Committee Matters": "098f9d5c048af2ae"
+    "Tax Matters": {
+      "Tax Covenants": {
+        "Other Tax Covenants / Tax Treatment of Payments": "e22eb654144286c2",
+      },
+      "Tax Disputes": {
+        "Tax Proceedings; Disputes and Audit Contests": "56e9ab8aac48d8f8",
+      },
+      "Tax Representations": {
+        "Tax Representations": "64756455cb6a8407",
+      },
+      "Transfer Taxes": {
+        "Transfer Taxes": "7fd16bf902d13048",
+      },
     },
-    "Post-Merger Governance": {
-      "Directors, Officers & Governance of Surviving Entity": "e38fc136fafbd07b"
-    },
-    "Shareholder Agreements & Voting": {
-      "Securityholder Representative Provisions": "8766fbc645223b7d",
-      "Voting, Support & Shareholder Agreements": "dccc050c7b770819"
-    },
-    "Takeover & Anti-Takeover": {
-      "Antitakeover / Takeover Statutes": "9dacfb2c929bbd9a",
-      "UK Takeover Panel Matters": "fc39027ced6e9b5e"
-    }
-  },
-  "Indemnification & Liability": {
-    "Indemnification Mechanics": {
-      "Indemnifiable Losses Definition": "c76c574a8f437a05",
-      "Indemnification Escrow & Holdback Provisions": "726b4f89306e679a",
-      "Indemnification Limitations (Caps & Baskets)": "a73e0398ad8b0104",
-      "Indemnification Procedures": "9613f111a9bf9db6"
-    },
-    "Indemnities": {
-      "Indemnification by Purchaser / Buyer": "b8ad9d98fefc6844",
-      "Indemnification by Seller / Target": "3f4a09babc73019c"
-    },
-    "Survival & Recourse": {
-      "D&O Indemnification & Insurance": "10866d4d64fc32c8",
-      "Indemnification \u2013 Exclusive Remedy / Sole Remedy": "0fefebbe62102092",
-      "Non-Recourse & Limited Liability": "8718c336dc859307",
-      "Seller Releases & Waivers": "d7ce59cfd33e134d",
-      "Survival / Non-Survival of Reps & Warranties": "949a439a8c96ba76"
-    }
-  },
-  "Regulatory & Compliance": {
-    "Antitrust & Competition": {
-      "Antitrust & Competition Filings": "3dd07ef88fe2d06c"
-    },
-    "Government Approvals": {
-      "Governmental Approvals & Consents": "5736fd3809ff8d95"
-    },
-    "Insider Trading & Section 16": {
-      "Section 16 & Insider Trading Compliance (incl. Rule 16b-3)": "2ef0d8d1ce1c1a8f"
-    },
-    "Securities Filings & Disclosure": {
-      "Proxy Statement, Prospectus & Registration Matters": "0fd42cc616dfd56b",
-      "Public Disclosure, Press Releases & SEC Communications": "2d33954063e3ae0e",
-      "Securities Documents & Capital Markets Filings": "7fcc5649a3985190"
-    },
-    "Stock Exchange": {
-      "Stock Exchange Listing": "52748f62ccff7015"
-    }
-  },
-  "Representations & Warranties": {
-    "Assets & Liabilities": {
-      "Accounts Receivable & Accounts Payable": "bf3939f8db1cdb5c",
-      "Assets; Inventory & Goodwill": "4c49669ab3e2a089",
-      "Casualty Loss and Condemnation": "ee49e752cab4d692",
-      "Deposits & Deposit Liabilities (Banking)": "d429b02c43f3f808",
-      "Excluded Assets": "8f15d7260c5376bf",
-      "Loan Portfolio & Asset Quality": "9f853034983a9a6a",
-      "Real Property & Tangible Assets": "93314630278e3f4d",
-      "Undisclosed Liabilities": "3589284e71431996"
-    },
-    "Books & Records": {
-      "Books & Records": "842de2d70fbf1443"
-    },
-    "Capital Structure": {
-      "Capitalization": "2091c8e1a4d26971",
-      "Stock Ownership Representations": "06b871f2e90569f1"
-    },
-    "Changes & Updates": {
-      "Absence of Certain Changes / Events": "ede429a629cd3b41"
-    },
-    "Contracts & Relationships": {
-      "Customers & Suppliers; Business Relationships": "7233d89a27c42583",
-      "Material Contracts & Commitments": "330d438a248a3d42",
-      "Related Party Transactions": "31ca3ad3458e621c"
-    },
-    "Corporate Organization & Authority": {
-      "Authority & Non-Contravention": "ae87408e3761beb1",
-      "Charter & Bylaws of Surviving Entity": "770417d31342dfdd",
-      "General / Introductory Representations & Warranties": "ab254c22aefab482",
-      "Merger Sub Representations": "431556a5a84f90cf",
-      "Organizational Matters (Existence, Qualification, Subsidiaries)": "206b2da0fb295d63",
-      "Solvency Representations": "914f006e880c9b38"
-    },
-    "Disclosure & Accuracy": {
-      "Disclaimer of Other Representations": "a41fcf985e05fab1",
-      "Disclosure; Accuracy of Information": "921ae6080f3d21a9"
-    },
-    "Financial Information & Controls": {
-      "Financial Projections & Forecasts": "60bc1d30739af1fd",
-      "Financial Statements & Accounting": "8516ebe5cd9bd0da",
-      "Interim Financial Information": "d202d93d2dd353f1",
-      "Internal Controls & Sarbanes-Oxley Compliance": "4f1df8f12a4b5a3d"
-    },
-    "Insurance & Warranty": {
-      "Insurance Matters": "b6a4646b170e7a10",
-      "Product Warranty & Liability": "10ac69129ed22eb0"
-    },
-    "Intellectual Property": {
-      "Intellectual Property": "2ba0f1c7aea9472c"
-    },
-    "Litigation & Disputes": {
-      "Litigation & Legal Proceedings": "662bf7d543cdddcf",
-      "Shareholder & Securityholder Litigation": "db6a86b940dd8b4f"
-    },
-    "Operational Compliance & Permits": {
-      "Anti-Corruption & FCPA Compliance": "9fe92383900ee52e",
-      "Compliance with Laws and Regulatory Matters": "d0a4735e95f26ac9",
-      "Data Privacy & Cybersecurity": "f39f22b4fcc6f60d",
-      "Environmental Matters": "8edf005cfab27fe0",
-      "Permits & Franchises": "e8e20e5fda2cbbda"
-    }
-  },
-  "Tax Matters": {
-    "Tax Covenants": {
-      "Other Tax Covenants / Tax Treatment of Payments": "e22eb654144286c2"
-    },
-    "Tax Disputes": {
-      "Tax Proceedings; Disputes and Audit Contests": "56e9ab8aac48d8f8"
-    },
-    "Tax Representations": {
-      "Tax Representations": "64756455cb6a8407"
-    },
-    "Transfer Taxes": {
-      "Transfer Taxes": "7fd16bf902d13048"
-    }
-  }
-};
+  };
 
   return (
     <div className="w-full font-roboto flex flex-col">
@@ -388,7 +403,7 @@ export default function Search() {
         {/* Action Buttons */}
         <div className="flex items-center gap-4">
           <button
-            onClick={() => actions.performSearch(true)}
+            onClick={() => actions.performSearch(true, clauseTypesNested)}
             disabled={isSearching}
             className={cn(
               "flex items-center justify-center gap-2 px-6 py-3 rounded-md bg-material-blue text-white text-[15px] font-medium leading-[26px] tracking-[0.46px] uppercase transition-all duration-200",

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -5,8 +5,10 @@ import {
   Download,
   FileText,
   ExternalLink,
+  Loader2,
 } from "lucide-react";
 import { useSearch } from "@/hooks/use-search";
+import { useFilterOptions } from "@/hooks/use-filter-options";
 import { SearchPagination } from "@/components/SearchPagination";
 import ErrorModal from "@/components/ErrorModal";
 import InfoModal from "@/components/InfoModal";
@@ -30,6 +32,14 @@ export default function Search() {
     showNoResultsModal,
     actions,
   } = useSearch();
+
+  // Get dynamic filter options
+  const {
+    targets,
+    acquirers,
+    isLoading: isLoadingFilterOptions,
+    error: filterOptionsError,
+  } = useFilterOptions();
 
   // Agreement modal state
   const [selectedAgreement, setSelectedAgreement] = useState<{
@@ -58,7 +68,7 @@ export default function Search() {
     setSelectedAgreement(null);
   };
 
-  // Placeholder data for dropdowns
+  // Static years data (not dynamic for now)
   const years = [
     "2020",
     "2019",
@@ -81,20 +91,6 @@ export default function Search() {
     "2002",
     "2001",
     "2000",
-  ];
-  const targets = [
-    "Apple Inc.",
-    "Microsoft Corp.",
-    "Google LLC",
-    "Amazon.com Inc.",
-    "Meta Platforms Inc.",
-  ];
-  const acquirers = [
-    "Berkshire Hathaway",
-    "JPMorgan Chase",
-    "Bank of America",
-    "Wells Fargo",
-    "Goldman Sachs",
   ];
 
   const clauseTypesNested = {
@@ -377,19 +373,33 @@ export default function Search() {
             onToggle={(value) => actions.toggleFilterValue("year", value)}
           />
 
-          <CheckboxFilter
-            label="Target"
-            options={targets}
-            selectedValues={filters.target || []}
-            onToggle={(value) => actions.toggleFilterValue("target", value)}
-          />
+          <div className="relative">
+            <CheckboxFilter
+              label="Target"
+              options={targets}
+              selectedValues={filters.target || []}
+              onToggle={(value) => actions.toggleFilterValue("target", value)}
+            />
+            {isLoadingFilterOptions && (
+              <div className="absolute inset-0 bg-white bg-opacity-75 flex items-center justify-center rounded">
+                <Loader2 className="w-4 h-4 animate-spin text-material-blue" />
+              </div>
+            )}
+          </div>
 
-          <CheckboxFilter
-            label="Acquirer"
-            options={acquirers}
-            selectedValues={filters.acquirer || []}
-            onToggle={(value) => actions.toggleFilterValue("acquirer", value)}
-          />
+          <div className="relative">
+            <CheckboxFilter
+              label="Acquirer"
+              options={acquirers}
+              selectedValues={filters.acquirer || []}
+              onToggle={(value) => actions.toggleFilterValue("acquirer", value)}
+            />
+            {isLoadingFilterOptions && (
+              <div className="absolute inset-0 bg-white bg-opacity-75 flex items-center justify-center rounded">
+                <Loader2 className="w-4 h-4 animate-spin text-material-blue" />
+              </div>
+            )}
+          </div>
 
           <NestedCheckboxFilter
             label="Clause Type"
@@ -399,6 +409,19 @@ export default function Search() {
             useModal={true}
           />
         </div>
+
+        {/* Filter Options Error */}
+        {filterOptionsError && (
+          <div className="bg-red-50 border border-red-200 rounded-md p-4">
+            <p className="text-red-800 text-sm">
+              <strong>Filter Options Error:</strong> {filterOptionsError}
+            </p>
+            <p className="text-red-600 text-xs mt-1">
+              Some filter options may not be available. Please refresh the page
+              to try again.
+            </p>
+          </div>
+        )}
 
         {/* Action Buttons */}
         <div className="flex items-center gap-4">

--- a/frontend/shared/search.ts
+++ b/frontend/shared/search.ts
@@ -30,6 +30,12 @@ export interface SearchResponse {
   totalPages: number;
 }
 
+// Filter options response from API
+export interface FilterOptionsResponse {
+  targets: string[];
+  acquirers: string[];
+}
+
 // Filter options (to be populated from API)
 export interface FilterOptions {
   years: string[];

--- a/frontend/shared/search.ts
+++ b/frontend/shared/search.ts
@@ -5,6 +5,7 @@ export interface SearchFilters {
   target?: string[];
   acquirer?: string[];
   clauseType?: string[];
+  standardId?: string[];
   page?: number;
   pageSize?: number;
 }


### PR DESCRIPTION
This change modifies the search functionality to extract standard IDs from selected clause types instead of sending clause type names directly.

Changes made:
- Added `extractStandardIds` function to recursively search nested clause type structure and extract corresponding standard IDs
- Updated `performSearch` function to accept optional `clauseTypesNested` parameter
- Modified search logic to extract standard IDs from selected clause types and send them as `standardId` parameters instead of `clauseType` parameters
- Added `standardId` field to `SearchFilters` interface and filter reset logic
- Updated search button click handler to pass `clauseTypesNested` data structure to `performSearch`
- Reformatted `clauseTypesNested` object structure for better readability

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d20297099941410ea76f12573adde4c2/glow-field)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d20297099941410ea76f12573adde4c2</projectId>-->
<!--<branchName>glow-field</branchName>-->