### PR TITLE
Add server-side pagination to search API and frontend

### DIFF
--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -23,6 +23,9 @@ export interface LLMOutputState {
 }
 
 export function useLLMOutput() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
   const [state, setState] = useState<LLMOutputState>({
     pageUuid: "",
     promptId: "",

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { apiUrl } from "@/lib/api-config";
 
 export interface LLMOutputState {

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -45,6 +45,7 @@ export function useLLMOutput() {
     errorMessage: "",
     showInfoModal: false,
     infoMessage: "",
+    showSaveSuccess: false,
   });
 
   // Load settings from localStorage on mount

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -20,6 +20,7 @@ export interface LLMOutputState {
   errorMessage: string;
   showInfoModal: boolean;
   infoMessage: string;
+  showSaveSuccess: boolean;
 }
 
 export function useLLMOutput() {

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -64,6 +64,38 @@ export function useLLMOutput() {
     }
   }, []);
 
+  // Handle PRG pattern - check for success state in URL parameters
+  useEffect(() => {
+    const saved = searchParams.get("saved");
+    const pageUuid = searchParams.get("pageUuid");
+    const timestamp = searchParams.get("timestamp");
+
+    if (saved === "true" && pageUuid && timestamp) {
+      // Show success state from redirect
+      setState((prev) => ({
+        ...prev,
+        pageUuid: pageUuid,
+        isSaved: true,
+        lastSaved: new Date(parseInt(timestamp)).toLocaleString(),
+      }));
+
+      // Clean up URL by removing the success parameters (optional)
+      // This creates a clean URL for bookmarking and sharing
+      const newParams = new URLSearchParams(searchParams);
+      newParams.delete("saved");
+      newParams.delete("pageUuid");
+      newParams.delete("timestamp");
+
+      // Replace current URL without the success parameters
+      navigate(
+        `/editor${newParams.toString() ? "?" + newParams.toString() : ""}`,
+        {
+          replace: true,
+        },
+      );
+    }
+  }, [searchParams, navigate]);
+
   // Save settings to localStorage whenever they change
   useEffect(() => {
     const settingsToSave = {

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -188,10 +188,6 @@ export function useLLMOutput() {
     localStorage.setItem("llm-output-settings", JSON.stringify(settingsToSave));
   }, [state.fontSize, state.pageUuid, state.llmOutput]);
 
-  const updateState = useCallback((updates: Partial<LLMOutputState>) => {
-    setState((prev) => ({ ...prev, ...updates }));
-  }, []);
-
   const calculateStats = useCallback(() => {
     const words = state.llmOutput.trim()
       ? state.llmOutput.trim().split(/\s+/).length

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -79,7 +79,13 @@ export function useLLMOutput() {
         pageUuid: pageUuid,
         isSaved: true,
         lastSaved: new Date(parseInt(timestamp)).toLocaleString(),
+        showSaveSuccess: true,
       }));
+
+      // Hide success message after 4 seconds
+      setTimeout(() => {
+        setState((prev) => ({ ...prev, showSaveSuccess: false }));
+      }, 4000);
 
       // Clean up URL by removing the success parameters (optional)
       // This creates a clean URL for bookmarking and sharing

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -205,68 +205,6 @@ export function useLLMOutput() {
     calculateStats();
   }, [calculateStats]);
 
-  const loadPage = useCallback(async () => {
-    if (!state.pageUuid.trim()) return;
-
-    updateState({ isLoading: true, lastSaved: "" });
-
-    try {
-      const res = await fetch(apiUrl(`api/llm/${state.pageUuid}`));
-
-      // Check if the response is ok (status 200-299)
-      if (!res.ok) {
-        if (res.status === 404) {
-          // UUID not found in database - this is informational, not an error
-          updateState({
-            showInfoModal: true,
-            infoMessage: "No page with that UUID exists in mna.llm_output.",
-          });
-          return;
-        }
-        // Other HTTP errors
-        throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-      }
-
-      const responseData = await res.json();
-
-      // Check if the response data is empty or null
-      if (!responseData || Object.keys(responseData).length === 0) {
-        updateState({
-          showInfoModal: true,
-          infoMessage: "No page with that UUID exists in mna.llm_output.",
-        });
-        return;
-      }
-
-      const { promptId, llmOutput, llmOutputCorrected } = responseData;
-      const output = llmOutputCorrected ?? llmOutput;
-
-      updateState({
-        promptId: promptId,
-        llmOutput: output,
-        isSaved: true,
-      });
-    } catch (error) {
-      console.error("Failed to load page:", error);
-      // Check if it's a network error
-      if (error instanceof TypeError && error.message.includes("fetch")) {
-        updateState({
-          showErrorModal: true,
-          errorMessage:
-            "Network error: unable to reach the back end database. Check your connection and try again.",
-        });
-      } else {
-        updateState({
-          showErrorModal: true,
-          errorMessage:
-            "Network error: unable to reach the back end database. Check your connection and try again.",
-        });
-      }
-    } finally {
-      updateState({ isLoading: false });
-    }
-  }, [state.pageUuid, updateState]);
-
   const requestSave = useCallback(() => {
     if (!state.llmOutput.trim()) return;
 

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -87,6 +87,14 @@ export function useLLMOutput() {
         setState((prev) => ({ ...prev, showSaveSuccess: false }));
       }, 4000);
 
+      // Auto-load the page data after showing success state
+      // This ensures the editor shows the saved content
+      if (pageUuid) {
+        setTimeout(() => {
+          loadPage();
+        }, 100); // Small delay to let state update first
+      }
+
       // Clean up URL by removing the success parameters (optional)
       // This creates a clean URL for bookmarking and sharing
       const newParams = new URLSearchParams(searchParams);
@@ -102,7 +110,7 @@ export function useLLMOutput() {
         },
       );
     }
-  }, [searchParams, navigate]);
+  }, [searchParams, navigate, loadPage]);
 
   // Save settings to localStorage whenever they change
   useEffect(() => {

--- a/frontend/client/hooks/use-llm-output.ts
+++ b/frontend/client/hooks/use-llm-output.ts
@@ -217,10 +217,13 @@ export function useLLMOutput() {
         throw new Error(`HTTP ${res.status}: ${res.statusText}`);
       }
 
-      updateState({
-        isSaved: true,
-        lastSaved: new Date().toLocaleString(),
-      });
+      // POST/Redirect/GET pattern:
+      // After successful save, redirect to the same page with success parameters
+      // This prevents resubmission on browser refresh
+      const timestamp = Date.now();
+      const successUrl = `/editor?saved=true&pageUuid=${encodeURIComponent(state.pageUuid)}&timestamp=${timestamp}`;
+
+      navigate(successUrl);
     } catch (error) {
       console.error("Failed to save page:", error);
       // Check if it's a network error
@@ -238,7 +241,7 @@ export function useLLMOutput() {
         });
       }
     }
-  }, [state.llmOutput, state.pageUuid, state.promptId, updateState]);
+  }, [state.llmOutput, state.pageUuid, state.promptId, updateState, navigate]);
 
   const cancelSave = useCallback(() => {
     updateState({ showSaveConfirmation: false });

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -343,17 +343,19 @@ export function useSearch() {
             );
           }
 
-          // Extract standard IDs from selected clause types
-          if (searchFilters.clauseType && searchFilters.clauseType.length > 0) {
-            // This would need the clauseTypesNested data - for now just use standardId filter if available
-            if (
-              searchFilters.standardId &&
-              searchFilters.standardId.length > 0
-            ) {
-              searchFilters.standardId.forEach((standardId) =>
-                params.append("standardId", standardId),
-              );
-            }
+          // Extract standard IDs from selected clause types and send them instead
+          if (
+            searchFilters.clauseType &&
+            searchFilters.clauseType.length > 0 &&
+            clauseTypesNested
+          ) {
+            const standardIds = extractStandardIds(
+              searchFilters.clauseType,
+              clauseTypesNested,
+            );
+            standardIds.forEach((standardId) =>
+              params.append("standardId", standardId),
+            );
           }
 
           // Set a very large page size to get all results

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -259,7 +259,7 @@ export function useSearch() {
         setIsSearching(false);
       }
     },
-    [filters],
+    [filters, currentSort, sortDirection],
   );
 
   // Helper function to check if any filters are applied

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -509,14 +509,14 @@ export function useSearch() {
     }
   }, [searchResults, selectedResults]);
 
-  // Auto-refresh results when sort direction changes or when new results are loaded
+  // Auto-refresh results when sort direction changes
   useEffect(() => {
     if (currentSort && searchResults.length > 0) {
       setSearchResults((prev) =>
         sortResultsArray(prev, currentSort, sortDirection),
       );
     }
-  }, [sortDirection, currentSort, searchResults.length, sortResultsArray]);
+  }, [sortDirection, currentSort]);
 
   return {
     filters,

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -427,11 +427,14 @@ export function useSearch() {
       pageSize: 25,
     });
     setSearchResults([]);
-    setAllResults([]);
     setSelectedResults(new Set());
     setHasSearched(false);
     setTotalCount(0);
     setTotalPages(0);
+    setHasNext(false);
+    setHasPrev(false);
+    setNextNum(null);
+    setPrevNum(null);
   }, []);
 
   const goToPage = useCallback(

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -279,138 +279,144 @@ export function useSearch() {
     );
   };
 
-  const downloadCSV = useCallback(async () => {
-    let resultsToDownload: SearchResult[] = [];
+  const downloadCSV = useCallback(
+    async (clauseTypesNested?: any) => {
+      let resultsToDownload: SearchResult[] = [];
 
-    if (selectedResults.size > 0) {
-      // If we have selected results, only download those from current page
-      resultsToDownload = searchResults.filter((result) =>
-        selectedResults.has(result.id),
-      );
-    } else {
-      // If no selected results, we need to fetch all results for the current filters
-      // This requires making a new API call without pagination to get all results
-      try {
-        const searchFilters = {
-          ...filters,
-          page: undefined,
-          pageSize: undefined,
-        };
-        const params = new URLSearchParams();
+      if (selectedResults.size > 0) {
+        // If we have selected results, only download those from current page
+        resultsToDownload = searchResults.filter((result) =>
+          selectedResults.has(result.id),
+        );
+      } else {
+        // If no selected results, we need to fetch all results for the current filters
+        // This requires making a new API call without pagination to get all results
+        try {
+          const searchFilters = {
+            ...filters,
+            page: undefined,
+            pageSize: undefined,
+          };
+          const params = new URLSearchParams();
 
-        // Build the same filter parameters as in performSearch
-        if (searchFilters.year && searchFilters.year.length > 0) {
-          searchFilters.year.forEach((year) => params.append("year", year));
-        }
-        if (searchFilters.target && searchFilters.target.length > 0) {
-          searchFilters.target.forEach((target) =>
-            params.append("target", target),
-          );
-        }
-        if (searchFilters.acquirer && searchFilters.acquirer.length > 0) {
-          searchFilters.acquirer.forEach((acquirer) =>
-            params.append("acquirer", acquirer),
-          );
-        }
-        if (
-          searchFilters.transactionSize &&
-          searchFilters.transactionSize.length > 0
-        ) {
-          searchFilters.transactionSize.forEach((size) =>
-            params.append("transactionSize", size),
-          );
-        }
-        if (
-          searchFilters.transactionType &&
-          searchFilters.transactionType.length > 0
-        ) {
-          searchFilters.transactionType.forEach((type) =>
-            params.append("transactionType", type),
-          );
-        }
-        if (
-          searchFilters.considerationType &&
-          searchFilters.considerationType.length > 0
-        ) {
-          searchFilters.considerationType.forEach((type) =>
-            params.append("considerationType", type),
-          );
-        }
-        if (searchFilters.targetType && searchFilters.targetType.length > 0) {
-          searchFilters.targetType.forEach((type) =>
-            params.append("targetType", type),
-          );
-        }
-
-        // Extract standard IDs from selected clause types
-        if (searchFilters.clauseType && searchFilters.clauseType.length > 0) {
-          // This would need the clauseTypesNested data - for now just use standardId filter if available
-          if (searchFilters.standardId && searchFilters.standardId.length > 0) {
-            searchFilters.standardId.forEach((standardId) =>
-              params.append("standardId", standardId),
+          // Build the same filter parameters as in performSearch
+          if (searchFilters.year && searchFilters.year.length > 0) {
+            searchFilters.year.forEach((year) => params.append("year", year));
+          }
+          if (searchFilters.target && searchFilters.target.length > 0) {
+            searchFilters.target.forEach((target) =>
+              params.append("target", target),
             );
           }
+          if (searchFilters.acquirer && searchFilters.acquirer.length > 0) {
+            searchFilters.acquirer.forEach((acquirer) =>
+              params.append("acquirer", acquirer),
+            );
+          }
+          if (
+            searchFilters.transactionSize &&
+            searchFilters.transactionSize.length > 0
+          ) {
+            searchFilters.transactionSize.forEach((size) =>
+              params.append("transactionSize", size),
+            );
+          }
+          if (
+            searchFilters.transactionType &&
+            searchFilters.transactionType.length > 0
+          ) {
+            searchFilters.transactionType.forEach((type) =>
+              params.append("transactionType", type),
+            );
+          }
+          if (
+            searchFilters.considerationType &&
+            searchFilters.considerationType.length > 0
+          ) {
+            searchFilters.considerationType.forEach((type) =>
+              params.append("considerationType", type),
+            );
+          }
+          if (searchFilters.targetType && searchFilters.targetType.length > 0) {
+            searchFilters.targetType.forEach((type) =>
+              params.append("targetType", type),
+            );
+          }
+
+          // Extract standard IDs from selected clause types
+          if (searchFilters.clauseType && searchFilters.clauseType.length > 0) {
+            // This would need the clauseTypesNested data - for now just use standardId filter if available
+            if (
+              searchFilters.standardId &&
+              searchFilters.standardId.length > 0
+            ) {
+              searchFilters.standardId.forEach((standardId) =>
+                params.append("standardId", standardId),
+              );
+            }
+          }
+
+          // Set a very large page size to get all results
+          params.append("pageSize", "10000");
+          params.append("page", "1");
+
+          const queryString = params.toString();
+          const res = await fetch(apiUrl(`api/search?${queryString}`));
+
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+          }
+
+          const searchResponse = (await res.json()) as SearchResponse;
+          resultsToDownload = searchResponse.results;
+        } catch (error) {
+          console.error("Failed to fetch all results for CSV:", error);
+          // Fallback to current page results
+          resultsToDownload = searchResults;
         }
-
-        // Set a very large page size to get all results
-        params.append("pageSize", "10000");
-        params.append("page", "1");
-
-        const queryString = params.toString();
-        const res = await fetch(apiUrl(`api/search?${queryString}`));
-
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-        }
-
-        const searchResponse = (await res.json()) as SearchResponse;
-        resultsToDownload = searchResponse.results;
-      } catch (error) {
-        console.error("Failed to fetch all results for CSV:", error);
-        // Fallback to current page results
-        resultsToDownload = searchResults;
       }
-    }
 
-    if (resultsToDownload.length === 0) return;
+      if (resultsToDownload.length === 0) return;
 
-    // Create CSV content
-    const headers = [
-      "Year",
-      "Target",
-      "Acquirer",
-      "Article Title",
-      "Section Title",
-      "Text",
-      "Section UUID",
-      "Agreement UUID",
-    ];
+      // Create CSV content
+      const headers = [
+        "Year",
+        "Target",
+        "Acquirer",
+        "Article Title",
+        "Section Title",
+        "Text",
+        "Section UUID",
+        "Agreement UUID",
+      ];
 
-    const csvContent = [
-      headers.join(","),
-      ...resultsToDownload.map((result) =>
-        [
-          result.year,
-          `"${result.target}"`,
-          `"${result.acquirer}"`,
-          `"${result.articleTitle}"`,
-          `"${result.sectionTitle}"`,
-          `"${result.xml.replace(/"/g, '""')}"`,
-          result.sectionUuid,
-          result.agreementUuid,
-        ].join(","),
-      ),
-    ].join("\n");
+      const csvContent = [
+        headers.join(","),
+        ...resultsToDownload.map((result) =>
+          [
+            result.year,
+            `"${result.target}"`,
+            `"${result.acquirer}"`,
+            `"${result.articleTitle}"`,
+            `"${result.sectionTitle}"`,
+            `"${result.xml.replace(/"/g, '""')}"`,
+            result.sectionUuid,
+            result.agreementUuid,
+          ].join(","),
+        ),
+      ].join("\n");
 
-    // Create and download file
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-    const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
-    const selectedText = selectedResults.size > 0 ? "_selected" : "";
-    link.download = `ma_clauses${selectedText}_${new Date().toISOString().split("T")[0]}.csv`;
-    link.click();
-    URL.revokeObjectURL(link.href);
-  }, [filters, searchResults, selectedResults]);
+      // Create and download file
+      const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+      const link = document.createElement("a");
+      link.href = URL.createObjectURL(blob);
+      const selectedText = selectedResults.size > 0 ? "_selected" : "";
+      link.download = `ma_clauses${selectedText}_${new Date().toISOString().split("T")[0]}.csv`;
+      link.click();
+      URL.revokeObjectURL(link.href);
+    },
+    [filters, searchResults, selectedResults],
+  );
 
   const clearFilters = useCallback(() => {
     setFilters({

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -128,10 +128,12 @@ export function useSearch() {
       }
 
       try {
-        const searchFilters = resetPage ? { ...filters, page: 1 } : filters;
-        if (resetPage) {
-          setFilters((prev) => ({ ...prev, page: 1 }));
-        }
+        // Use current filters state
+        setFilters((currentFilters) => {
+          const searchFilters = resetPage ? { ...currentFilters, page: 1 } : currentFilters;
+
+          // Execute the search with current filters
+          (async () => {
 
         const params = new URLSearchParams();
 
@@ -213,7 +215,7 @@ export function useSearch() {
         }
 
         // Parse as SearchResponse with pagination metadata
-        const searchResponse = (await res.json()) as SearchResponse;
+        const searchResponse = await res.json() as SearchResponse;
 
         // Apply client-side sorting to the current page results
         const sortedResults = sortResultsArray(
@@ -284,18 +286,12 @@ export function useSearch() {
 
     if (selectedResults.size > 0) {
       // If we have selected results, only download those from current page
-      resultsToDownload = searchResults.filter((result) =>
-        selectedResults.has(result.id),
-      );
+      resultsToDownload = searchResults.filter((result) => selectedResults.has(result.id));
     } else {
       // If no selected results, we need to fetch all results for the current filters
       // This requires making a new API call without pagination to get all results
       try {
-        const searchFilters = {
-          ...filters,
-          page: undefined,
-          pageSize: undefined,
-        };
+        const searchFilters = { ...filters, page: undefined, pageSize: undefined };
         const params = new URLSearchParams();
 
         // Build the same filter parameters as in performSearch
@@ -343,7 +339,10 @@ export function useSearch() {
         }
 
         // Extract standard IDs from selected clause types
-        if (searchFilters.clauseType && searchFilters.clauseType.length > 0) {
+        if (
+          searchFilters.clauseType &&
+          searchFilters.clauseType.length > 0
+        ) {
           // This would need the clauseTypesNested data - for now just use standardId filter if available
           if (searchFilters.standardId && searchFilters.standardId.length > 0) {
             searchFilters.standardId.forEach((standardId) =>
@@ -363,7 +362,7 @@ export function useSearch() {
           throw new Error(`HTTP ${res.status}: ${res.statusText}`);
         }
 
-        const searchResponse = (await res.json()) as SearchResponse;
+        const searchResponse = await res.json() as SearchResponse;
         resultsToDownload = searchResponse.results;
       } catch (error) {
         console.error("Failed to fetch all results for CSV:", error);

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -435,32 +435,23 @@ export function useSearch() {
   }, []);
 
   const goToPage = useCallback(
-    (page: number) => {
+    async (page: number, clauseTypesNested?: any) => {
       setFilters((prev) => ({ ...prev, page }));
 
-      // Apply pagination on frontend if we have all results
-      if (allResults.length > 0) {
-        const startIndex = (page - 1) * (filters.pageSize || 25);
-        const endIndex = startIndex + (filters.pageSize || 25);
-        const paginatedResults = allResults.slice(startIndex, endIndex);
-        setSearchResults(paginatedResults);
-      }
+      // Trigger a new search with the new page number
+      await performSearch(false, clauseTypesNested);
     },
-    [allResults, filters.pageSize],
+    [performSearch],
   );
 
   const changePageSize = useCallback(
-    (pageSize: number) => {
+    async (pageSize: number, clauseTypesNested?: any) => {
       setFilters((prev) => ({ ...prev, pageSize, page: 1 }));
 
-      // Apply new page size on frontend if we have all results
-      if (allResults.length > 0) {
-        setTotalPages(Math.ceil(allResults.length / pageSize));
-        const paginatedResults = allResults.slice(0, pageSize);
-        setSearchResults(paginatedResults);
-      }
+      // Trigger a new search with the new page size and reset to page 1
+      await performSearch(false, clauseTypesNested);
     },
-    [allResults],
+    [performSearch],
   );
 
   const closeErrorModal = useCallback(() => {

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -128,12 +128,10 @@ export function useSearch() {
       }
 
       try {
-        // Use current filters state
-        setFilters((currentFilters) => {
-          const searchFilters = resetPage ? { ...currentFilters, page: 1 } : currentFilters;
-
-          // Execute the search with current filters
-          (async () => {
+        const searchFilters = resetPage ? { ...filters, page: 1 } : filters;
+        if (resetPage) {
+          setFilters((prev) => ({ ...prev, page: 1 }));
+        }
 
         const params = new URLSearchParams();
 
@@ -215,7 +213,7 @@ export function useSearch() {
         }
 
         // Parse as SearchResponse with pagination metadata
-        const searchResponse = await res.json() as SearchResponse;
+        const searchResponse = (await res.json()) as SearchResponse;
 
         // Apply client-side sorting to the current page results
         const sortedResults = sortResultsArray(
@@ -286,12 +284,18 @@ export function useSearch() {
 
     if (selectedResults.size > 0) {
       // If we have selected results, only download those from current page
-      resultsToDownload = searchResults.filter((result) => selectedResults.has(result.id));
+      resultsToDownload = searchResults.filter((result) =>
+        selectedResults.has(result.id),
+      );
     } else {
       // If no selected results, we need to fetch all results for the current filters
       // This requires making a new API call without pagination to get all results
       try {
-        const searchFilters = { ...filters, page: undefined, pageSize: undefined };
+        const searchFilters = {
+          ...filters,
+          page: undefined,
+          pageSize: undefined,
+        };
         const params = new URLSearchParams();
 
         // Build the same filter parameters as in performSearch
@@ -339,10 +343,7 @@ export function useSearch() {
         }
 
         // Extract standard IDs from selected clause types
-        if (
-          searchFilters.clauseType &&
-          searchFilters.clauseType.length > 0
-        ) {
+        if (searchFilters.clauseType && searchFilters.clauseType.length > 0) {
           // This would need the clauseTypesNested data - for now just use standardId filter if available
           if (searchFilters.standardId && searchFilters.standardId.length > 0) {
             searchFilters.standardId.forEach((standardId) =>
@@ -362,7 +363,7 @@ export function useSearch() {
           throw new Error(`HTTP ${res.status}: ${res.statusText}`);
         }
 
-        const searchResponse = await res.json() as SearchResponse;
+        const searchResponse = (await res.json()) as SearchResponse;
         resultsToDownload = searchResponse.results;
       } catch (error) {
         console.error("Failed to fetch all results for CSV:", error);

--- a/frontend/client/hooks/use-search.ts
+++ b/frontend/client/hooks/use-search.ts
@@ -71,7 +71,6 @@ export function useSearch() {
 
   const [isSearching, setIsSearching] = useState(false);
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
-  const [allResults, setAllResults] = useState<SearchResult[]>([]);
   const [selectedResults, setSelectedResults] = useState<Set<string>>(
     new Set(),
   );
@@ -85,6 +84,11 @@ export function useSearch() {
   const [currentSort, setCurrentSort] = useState<
     "year" | "target" | "acquirer" | null
   >("year");
+  // Pagination metadata from API
+  const [hasNext, setHasNext] = useState(false);
+  const [hasPrev, setHasPrev] = useState(false);
+  const [nextNum, setNextNum] = useState<number | null>(null);
+  const [prevNum, setPrevNum] = useState<number | null>(null);
 
   const updateFilter = useCallback(
     (field: keyof SearchFilters, value: string | string[]) => {

--- a/frontend/client/pages/Edit.tsx
+++ b/frontend/client/pages/Edit.tsx
@@ -205,6 +205,13 @@ export default function Index() {
         </div>
       )}
 
+      {/* Save Success Toast */}
+      {state.showSaveSuccess && (
+        <div className="fixed bottom-6 right-6 bg-green-600 text-white px-4 py-2 rounded shadow-[0_10px_15px_-3px_rgb(0_0_0_/_0.1),0_4px_6px_-4px_rgb(0_0_0_/_0.1)] text-sm">
+          Changes saved successfully!
+        </div>
+      )}
+
       {/* Save Confirmation Modal */}
       <SaveConfirmationModal
         isOpen={state.showSaveConfirmation}

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -172,7 +172,7 @@ export default function Search() {
       "Purchase Price & Adjustments": {
         "Contingent Value Rights (CVR) & Earn-Out Agreements":
           "753cece4c610bcc3",
-        "Distributions": "17a1631998eb3cef",
+        Distributions: "17a1631998eb3cef",
         "Fairness Opinions & Financial Advisors": "d7ae412fdcc9d956",
         "Purchase Price and Post-Closing Adjustments": "2b4119d25d6309ee",
       },
@@ -181,7 +181,7 @@ export default function Search() {
         "Stock Issuance & Reservation": "2014181a8401598b",
       },
     },
-    "Covenants": {
+    Covenants: {
       "Disclosure Schedule Interpretation": {
         "Disclosure Schedule Interpretation & Cross-References":
           "12778ed5811cb2c7",
@@ -237,7 +237,7 @@ export default function Search() {
         "Amendments; Extensions; Waivers": "c20cd24a0d84ba56",
         "Arbitration & Dispute Resolution": "f383ecddb78f002f",
         "Assignment & Successors": "305bb88f1e98b4d4",
-        "Confidentiality": "6df8bc88edff7e3d",
+        Confidentiality: "6df8bc88edff7e3d",
         "Counterparts & Electronic Signatures": "d44006cdbbb8ad0c",
         "Entire Agreement": "10cd17a4560a7a7d",
         "Governing Law; Jurisdiction; Jury Trial": "b79e1996d2f7bcac",
@@ -250,7 +250,7 @@ export default function Search() {
         "Service of Process": "433ef1632fe94c19",
         "Severability and Boilerplate Provisions": "2560701d69ecbaff",
       },
-      "Definitions": {
+      Definitions: {
         "Definitions & Interpretation": "beee4c5deefdc2d0",
       },
       "Expenses & Advisors": {
@@ -283,7 +283,7 @@ export default function Search() {
         "Indemnification Limitations (Caps & Baskets)": "a73e0398ad8b0104",
         "Indemnification Procedures": "9613f111a9bf9db6",
       },
-      "Indemnities": {
+      Indemnities: {
         "Indemnification by Purchaser / Buyer": "b8ad9d98fefc6844",
         "Indemnification by Seller / Target": "3f4a09babc73019c",
       },
@@ -333,7 +333,7 @@ export default function Search() {
         "Books & Records": "842de2d70fbf1443",
       },
       "Capital Structure": {
-        "Capitalization": "2091c8e1a4d26971",
+        Capitalization: "2091c8e1a4d26971",
         "Stock Ownership Representations": "06b871f2e90569f1",
       },
       "Changes & Updates": {
@@ -530,8 +530,12 @@ export default function Search() {
                         totalPages={totalPages}
                         pageSize={pageSize}
                         totalCount={totalCount}
-                        onPageChange={actions.goToPage}
-                        onPageSizeChange={actions.changePageSize}
+                        onPageChange={(page) =>
+                          actions.goToPage(page, clauseTypesNested)
+                        }
+                        onPageSizeChange={(pageSize) =>
+                          actions.changePageSize(pageSize, clauseTypesNested)
+                        }
                         isLoading={isSearching}
                       />
 

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -484,7 +484,7 @@ export default function Search() {
             </Button>
 
             <Button
-              onClick={actions.downloadCSV}
+              onClick={() => actions.downloadCSV(clauseTypesNested)}
               disabled={
                 searchResults.length === 0 && selectedResults.size === 0
               }

--- a/frontend/client/pages/Search.tsx
+++ b/frontend/client/pages/Search.tsx
@@ -557,8 +557,12 @@ export default function Search() {
                         totalPages={totalPages}
                         pageSize={pageSize}
                         totalCount={totalCount}
-                        onPageChange={actions.goToPage}
-                        onPageSizeChange={actions.changePageSize}
+                        onPageChange={(page) =>
+                          actions.goToPage(page, clauseTypesNested)
+                        }
+                        onPageSizeChange={(pageSize) =>
+                          actions.changePageSize(pageSize, clauseTypesNested)
+                        }
                         isLoading={isSearching}
                       />
                     </>

--- a/frontend/shared/search.ts
+++ b/frontend/shared/search.ts
@@ -32,6 +32,10 @@ export interface SearchResponse {
   page: number;
   pageSize: number;
   totalPages: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+  nextNum: number | null;
+  prevNum: number | null;
 }
 
 // Filter options response from API


### PR DESCRIPTION
This pull request implements server-side pagination for the search functionality to improve performance and user experience.

Backend changes:
- Add pagination parameters (page, pageSize) to search_sections endpoint
- Implement pagination validation with default page size of 25 and max of 100
- Use SQLAlchemy's paginate() method for database queries
- Return pagination metadata including hasNext, hasPrev, nextNum, prevNum
- Add error handling for pagination failures

Frontend changes:
- Update search hook to handle server-side pagination
- Remove client-side pagination logic and allResults state
- Add pagination metadata state variables (hasNext, hasPrev, etc.)
- Modify goToPage and changePageSize to trigger new API requests
- Update CSV download to fetch all results with large page size
- Pass clauseTypesNested parameter to pagination functions

Editor improvements:
- Implement POST/Redirect/GET pattern for save operations
- Add success toast notification after saving
- Handle URL parameters for save success state
- Clean up URLs after displaying success messages

The changes ensure better performance for large datasets by only loading the current page of results from the database, while maintaining all existing functionality including sorting, filtering, and CSV export.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d20297099941410ea76f12573adde4c2/cosmos-world)

👀 [Preview Link](https://d20297099941410ea76f12573adde4c2-cosmos-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d20297099941410ea76f12573adde4c2</projectId>-->
<!--<branchName>cosmos-world</branchName>-->