### PR TITLE
Improve SearchSidebar content visibility timing

### DIFF
--- a/frontend/client/components/SearchSidebar.tsx
+++ b/frontend/client/components/SearchSidebar.tsx
@@ -41,7 +41,7 @@ export function SearchSidebar({
   isCollapsed,
   className,
 }: SearchSidebarProps) {
-  const [showContent, setShowContent] = useState(!isCollapsed);
+  const [showContent, setShowContent] = useState(false);
 
   // Control content visibility with proper timing
   React.useEffect(() => {
@@ -50,10 +50,17 @@ export function SearchSidebar({
       setShowContent(false);
     } else {
       // Show content after expansion animation completes
-      const timer = setTimeout(() => setShowContent(true), 300);
+      const timer = setTimeout(() => setShowContent(true), 320);
       return () => clearTimeout(timer);
     }
   }, [isCollapsed]);
+
+  // Initialize content visibility on mount
+  React.useEffect(() => {
+    if (!isCollapsed) {
+      setShowContent(true);
+    }
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
Replace transition tracking with content visibility control in SearchSidebar component.

Changes:
- Replace `isTransitioning` state with `showContent` state
- Hide content immediately when sidebar collapses
- Show content after 320ms delay when sidebar expands
- Add useEffect to initialize content visibility on mount
- Update sidebar height to use calc(100vh-4rem) for both collapsed and expanded states
- Change content rendering condition from `!isCollapsed` to `showContent`

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/d20297099941410ea76f12573adde4c2/flare-den)

👀 [Preview Link](https://d20297099941410ea76f12573adde4c2-flare-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d20297099941410ea76f12573adde4c2</projectId>-->
<!--<branchName>flare-den</branchName>-->