### PR TITLE
Replace mock data with real API call in BulkData page

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -607,7 +607,7 @@ class DumpDownloadResource(MethodView):
 class DumpManifestResource(MethodView):
     def get(self, filename):
         """Download a manifest file by proxying through R2"""
-                try:
+        try:
             # Handle different filename formats
             if filename.endswith('.manifest.json'):
                 # Full manifest filename like "db_dump_2025-07-18_04-15.sql.gz.manifest.json"

--- a/backend/app.py
+++ b/backend/app.py
@@ -42,7 +42,7 @@ app.config.update({
 
 api = Api(app)
 
-# ── CORS setup ──────────────────────────────────────────────────────────
+# ── CORS setup ��─────────────────────────────────────────────────────────
 CORS(
     app,
     resources={
@@ -198,7 +198,7 @@ class DumpEntrySchema(Schema):
     sha256    = fields.Url(required=False, allow_none=True)
     manifest  = fields.Url(required=False, allow_none=True)
     
-# ── Route definitions ───────────────────────────────────────
+# ── Route definitions ────────────────────────���──────────────
 @app.route("/api/llm/<string:page_uuid>", methods=["GET"])
 def get_llm(page_uuid):
     # pick the most-recent prompt for this page (excluding SKIP outputs)
@@ -611,11 +611,18 @@ class DumpManifestResource(MethodView):
             # Handle both .json and .manifest.json extensions
             if filename.endswith('.json'):
                 key = f"dumps/{filename}"
+                download_filename = filename
             elif filename.endswith('.manifest.json'):
                 key = f"dumps/{filename}"
+                download_filename = filename
             else:
                 # Assume it's a base filename and add .manifest.json
                 key = f"dumps/{filename}.manifest.json"
+                download_filename = f"{filename}.manifest.json"
+
+            # Ensure download filename ends with .json
+            if not download_filename.endswith('.json'):
+                download_filename = f"{download_filename}.json"
 
             # Get object from R2
             response = client.get_object(
@@ -630,7 +637,7 @@ class DumpManifestResource(MethodView):
                 content,
                 mimetype='application/json',
                 headers={
-                    'Content-Disposition': f'attachment; filename="{filename}"',
+                    'Content-Disposition': f'attachment; filename="{download_filename}"',
                     'Content-Type': 'application/json'
                 }
             )

--- a/backend/app.py
+++ b/backend/app.py
@@ -564,7 +564,7 @@ class DumpListResource(MethodView):
 
             dump_list.append(entry)
 
-                return dump_list
+            return dump_list
 
 @dumps_blp.route("/download/<string:filename>")
 class DumpDownloadResource(MethodView):

--- a/backend/app.py
+++ b/backend/app.py
@@ -562,7 +562,7 @@ class DumpListResource(MethodView):
                 except Exception as e:
                     entry["warning"] = f"couldn't read manifest: {e}"
 
-                    dump_list.append(entry)
+            dump_list.append(entry)
 
         return dump_list
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 import click
 import json
-from flask import Flask, jsonify, request, abort
+from flask import Flask, jsonify, request, abort, Response
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
 from flask_smorest import Api, Blueprint
@@ -83,7 +83,7 @@ app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
 db = SQLAlchemy(app)
 
-# ── Reflect existing tables via standalone engine ─────────────────────────
+# ── Reflect existing tables via standalone engine ���────────────────────────
 engine = create_engine(app.config["SQLALCHEMY_DATABASE_URI"])
 metadata = MetaData()
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -42,7 +42,7 @@ app.config.update({
 
 api = Api(app)
 
-# ── CORS setup ──────────────────────────────────────────────────────────
+# ── CORS setup ───────���──────────────────────────────────────────────────
 CORS(
     app,
     resources={
@@ -562,9 +562,9 @@ class DumpListResource(MethodView):
                 except Exception as e:
                     entry["warning"] = f"couldn't read manifest: {e}"
 
-            dump_list.append(entry)
+                        dump_list.append(entry)
 
-            return dump_list
+        return dump_list
 
 @dumps_blp.route("/download/<string:filename>")
 class DumpDownloadResource(MethodView):

--- a/backend/app.py
+++ b/backend/app.py
@@ -562,7 +562,7 @@ class DumpListResource(MethodView):
                 except Exception as e:
                     entry["warning"] = f"couldn't read manifest: {e}"
 
-                        dump_list.append(entry)
+                    dump_list.append(entry)
 
         return dump_list
 

--- a/frontend/client/components/Footer.tsx
+++ b/frontend/client/components/Footer.tsx
@@ -18,7 +18,7 @@ export default function Footer() {
         <div className="flex items-center justify-between">
           {/* Copyright on the left */}
           <div className="text-xs text-gray-400">
-            © {currentYear} Nikita Bogdanov • Subject to{" "}
+            © {currentYear} Nikita Bogdanov • Use subject to{" "}
             <a
               href="https://www.gnu.org/licenses/gpl-3.0.en.html"
               target="_blank"
@@ -27,7 +27,7 @@ export default function Footer() {
             >
               GNU GPLv3
             </a>{" "}
-            license
+            license.
           </div>
 
           {/* GitHub logo in the center - just icon */}

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -32,6 +32,11 @@ export default function BulkData() {
 
         const data: DumpInfo[] = await response.json();
 
+        // Find the latest version's SHA256
+        const latest = data.find((dump) => dump.timestamp === "latest");
+        const latestHash = latest?.sha256 || null;
+        setLatestSha256(latestHash);
+
         // Sort so 'latest' is always first, then sort others by timestamp
         const sortedData = data.sort((a, b) => {
           if (a.timestamp === "latest") return -1;

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -310,17 +310,17 @@ export default function BulkData() {
                       <td className="px-6 py-4 whitespace-nowrap">
                         <div className="flex space-x-2">
                           <a
-                            href={dump.sql}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                            href={apiUrl(
+                              `api/dumps/download/${dump.sql.split("/").pop()}`,
+                            )}
                             className="inline-flex items-center px-3 py-1 border border-material-blue text-material-blue hover:bg-material-blue hover:text-white rounded text-sm font-medium transition-colors"
                           >
                             Download SQL
                           </a>
                           <a
-                            href={dump.manifest}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                            href={apiUrl(
+                              `api/dumps/manifest/${dump.manifest.split("/").pop()}`,
+                            )}
                             className="inline-flex items-center px-3 py-1 border border-gray-300 text-gray-700 hover:bg-gray-50 rounded text-sm font-medium transition-colors"
                           >
                             Manifest

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -17,6 +17,7 @@ export default function BulkData() {
   const [copiedStates, setCopiedStates] = useState<{ [key: string]: boolean }>(
     {},
   );
+  const [latestSha256, setLatestSha256] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchDumps = async () => {

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -291,6 +291,13 @@ export default function BulkData() {
                               Latest Version
                             </span>
                           )}
+                          {dump.timestamp !== "latest" &&
+                            latestSha256 &&
+                            dump.sha256 === latestSha256 && (
+                              <span className="text-xs text-green-600 font-medium">
+                                Same as Latest
+                              </span>
+                            )}
                         </div>
                       </td>
                       <td className="px-6 py-4">


### PR DESCRIPTION
Replace mock data implementation with actual API integration for the BulkData page.

Changes made:
- Remove mock data and setTimeout simulation
- Add real API call to fetch dumps from `/api/dumps` endpoint
- Update DumpInfo interface to include manifest and sql fields, replace size/date with timestamp
- Add proper error handling and loading states for API calls
- Implement sorting logic to show 'latest' version first, then by timestamp descending
- Update formatTimestamp function to handle 'latest' and timestamp format parsing
- Modify table headers from "Date/Size" to "Version/Actions"
- Add copy-to-clipboard functionality for SHA256 hashes
- Replace single download link with separate "Download SQL" and "Manifest" buttons
- Improve UI with better styling and visual indicators for latest version

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/d20297099941410ea76f12573adde4c2/vibe-den)

👀 [Preview Link](https://d20297099941410ea76f12573adde4c2-vibe-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d20297099941410ea76f12573adde4c2</projectId>-->
<!--<branchName>vibe-den</branchName>-->