### PR TITLE
Improve footer layout and code block styling

### DIFF
--- a/frontend/client/components/Footer.tsx
+++ b/frontend/client/components/Footer.tsx
@@ -15,7 +15,7 @@ export default function Footer() {
           paddingRight: "48px",
         }}
       >
-        <div className="flex items-center justify-between">
+        <div className="relative flex items-center">
           {/* Copyright on the left */}
           <div className="text-xs text-gray-400">
             © {currentYear} Nikita Bogdanov • Use subject to{" "}
@@ -30,8 +30,8 @@ export default function Footer() {
             license.
           </div>
 
-          {/* GitHub logo in the center - just icon */}
-          <div className="flex-1 flex justify-center">
+          {/* GitHub logo centered on the page */}
+          <div className="absolute left-1/2 transform -translate-x-1/2">
             <a
               href="https://github.com/PlatosTwin/pandects-app"
               target="_blank"
@@ -42,9 +42,6 @@ export default function Footer() {
               <Github className="w-4 h-4" />
             </a>
           </div>
-
-          {/* Empty div for balance */}
-          <div className="w-24" />
         </div>
       </div>
     </footer>

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -126,7 +126,7 @@ export default function BulkData() {
             <h3 className="text-lg font-semibold text-material-text-primary mb-3">
               Get Latest Version
             </h3>
-            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[120px] flex items-center">
+            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[100px] flex flex-col justify-center">
               <button
                 onClick={() =>
                   copyToClipboard(
@@ -143,7 +143,7 @@ export default function BulkData() {
                   <Copy className="w-3 h-3 text-gray-600" />
                 )}
               </button>
-              <div className="overflow-x-auto pb-3 w-full">
+              <div className="overflow-x-auto pb-2">
                 <div className="text-gray-600 mb-2">
                   # API call to get latest dump info
                 </div>

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -191,7 +191,7 @@ export default function BulkData() {
             <h3 className="text-lg font-semibold text-material-text-primary mb-3">
               Verify Checksum
             </h3>
-            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group">
+            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[80px]">
               <button
                 onClick={() =>
                   copyToClipboard(
@@ -208,7 +208,7 @@ export default function BulkData() {
                   <Copy className="w-3 h-3 text-gray-600" />
                 )}
               </button>
-              <div className="overflow-x-auto">
+              <div className="overflow-x-auto pb-2">
                 <div className="text-gray-600 mb-2">
                   # Verify file integrity
                 </div>

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -143,12 +143,14 @@ export default function BulkData() {
                   <Copy className="w-3 h-3 text-gray-600" />
                 )}
               </button>
-              <div className="overflow-x-auto pb-2">
-                <div className="text-gray-600 mb-2">
-                  # API call to get latest dump info
-                </div>
-                <div className="whitespace-nowrap pr-10">
-                  curl https://pandects-api.fly.dev/api/dumps/latest
+              <div className="overflow-x-auto pb-2 flex-1 flex flex-col justify-center">
+                <div>
+                  <div className="text-gray-600 mb-2">
+                    # API call to get latest dump info
+                  </div>
+                  <div className="whitespace-nowrap pr-10">
+                    curl https://pandects-api.fly.dev/api/dumps/latest
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -214,12 +214,14 @@ export default function BulkData() {
                   <Copy className="w-3 h-3 text-gray-600" />
                 )}
               </button>
-              <div className="overflow-x-auto pb-2">
-                <div className="text-gray-600 mb-2">
-                  # Verify file integrity
-                </div>
-                <div className="whitespace-nowrap pr-10">
-                  echo "sha256_hash filename.sql.gz" | sha256sum -c
+              <div className="overflow-x-auto pb-2 flex-1 flex flex-col justify-center">
+                <div>
+                  <div className="text-gray-600 mb-2">
+                    # Verify file integrity
+                  </div>
+                  <div className="whitespace-nowrap pr-10">
+                    echo "sha256_hash filename.sql.gz" | sha256sum -c
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -159,7 +159,7 @@ export default function BulkData() {
             <h3 className="text-lg font-semibold text-material-text-primary mb-3">
               Download with wget
             </h3>
-            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[120px] flex items-center">
+            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[100px] flex flex-col justify-center">
               <button
                 onClick={() =>
                   copyToClipboard(
@@ -176,7 +176,7 @@ export default function BulkData() {
                   <Copy className="w-3 h-3 text-gray-600" />
                 )}
               </button>
-              <div className="overflow-x-auto pb-3 w-full">
+              <div className="overflow-x-auto pb-2">
                 <div className="text-gray-600 mb-2"># Download latest dump</div>
                 <div className="whitespace-nowrap pr-10">
                   wget

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -159,7 +159,7 @@ export default function BulkData() {
             <h3 className="text-lg font-semibold text-material-text-primary mb-3">
               Download with wget
             </h3>
-            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group">
+            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[80px]">
               <button
                 onClick={() =>
                   copyToClipboard(
@@ -176,7 +176,7 @@ export default function BulkData() {
                   <Copy className="w-3 h-3 text-gray-600" />
                 )}
               </button>
-              <div className="overflow-x-auto">
+              <div className="overflow-x-auto pb-2">
                 <div className="text-gray-600 mb-2"># Download latest dump</div>
                 <div className="whitespace-nowrap pr-10">
                   wget

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -126,7 +126,7 @@ export default function BulkData() {
             <h3 className="text-lg font-semibold text-material-text-primary mb-3">
               Get Latest Version
             </h3>
-            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[80px]">
+            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[120px] flex items-center">
               <button
                 onClick={() =>
                   copyToClipboard(
@@ -143,7 +143,7 @@ export default function BulkData() {
                   <Copy className="w-3 h-3 text-gray-600" />
                 )}
               </button>
-              <div className="overflow-x-auto pb-2">
+              <div className="overflow-x-auto pb-3 w-full">
                 <div className="text-gray-600 mb-2">
                   # API call to get latest dump info
                 </div>

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -159,7 +159,7 @@ export default function BulkData() {
             <h3 className="text-lg font-semibold text-material-text-primary mb-3">
               Download with wget
             </h3>
-            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[80px]">
+            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[120px] flex items-center">
               <button
                 onClick={() =>
                   copyToClipboard(
@@ -176,7 +176,7 @@ export default function BulkData() {
                   <Copy className="w-3 h-3 text-gray-600" />
                 )}
               </button>
-              <div className="overflow-x-auto pb-2">
+              <div className="overflow-x-auto pb-3 w-full">
                 <div className="text-gray-600 mb-2"># Download latest dump</div>
                 <div className="whitespace-nowrap pr-10">
                   wget

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -126,7 +126,7 @@ export default function BulkData() {
             <h3 className="text-lg font-semibold text-material-text-primary mb-3">
               Get Latest Version
             </h3>
-            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group">
+            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[80px]">
               <button
                 onClick={() =>
                   copyToClipboard(
@@ -143,7 +143,7 @@ export default function BulkData() {
                   <Copy className="w-3 h-3 text-gray-600" />
                 )}
               </button>
-              <div className="overflow-x-auto">
+              <div className="overflow-x-auto pb-2">
                 <div className="text-gray-600 mb-2">
                   # API call to get latest dump info
                 </div>

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -178,11 +178,15 @@ export default function BulkData() {
                   <Copy className="w-3 h-3 text-gray-600" />
                 )}
               </button>
-              <div className="overflow-x-auto pb-2">
-                <div className="text-gray-600 mb-2"># Download latest dump</div>
-                <div className="whitespace-nowrap pr-10">
-                  wget
-                  https://dash.cloudflare.com/34730161d8a80dadcd289d6774ffff3d/r2/default/buckets/pandects-bulk/objects/dumps%2Flatest.sql.gz/details
+              <div className="overflow-x-auto pb-2 flex-1 flex flex-col justify-center">
+                <div>
+                  <div className="text-gray-600 mb-2">
+                    # Download latest dump
+                  </div>
+                  <div className="whitespace-nowrap pr-10">
+                    wget
+                    https://dash.cloudflare.com/34730161d8a80dadcd289d6774ffff3d/r2/default/buckets/pandects-bulk/objects/dumps%2Flatest.sql.gz/details
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -191,7 +191,7 @@ export default function BulkData() {
             <h3 className="text-lg font-semibold text-material-text-primary mb-3">
               Verify Checksum
             </h3>
-            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[80px]">
+            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[100px] flex flex-col justify-center">
               <button
                 onClick={() =>
                   copyToClipboard(

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -126,7 +126,7 @@ export default function BulkData() {
             <h3 className="text-lg font-semibold text-material-text-primary mb-3">
               Get Latest Version
             </h3>
-            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[100px] flex flex-col justify-center">
+            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[85px] flex flex-col justify-center">
               <button
                 onClick={() =>
                   copyToClipboard(
@@ -161,7 +161,7 @@ export default function BulkData() {
             <h3 className="text-lg font-semibold text-material-text-primary mb-3">
               Download with wget
             </h3>
-            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[100px] flex flex-col justify-center">
+            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[85px] flex flex-col justify-center">
               <button
                 onClick={() =>
                   copyToClipboard(
@@ -197,7 +197,7 @@ export default function BulkData() {
             <h3 className="text-lg font-semibold text-material-text-primary mb-3">
               Verify Checksum
             </h3>
-            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[100px] flex flex-col justify-center">
+            <div className="bg-gray-50 rounded p-4 text-xs font-mono relative group min-h-[85px] flex flex-col justify-center">
               <button
                 onClick={() =>
                   copyToClipboard(


### PR DESCRIPTION
Updates footer component layout and code block styling in BulkData page.

Footer changes:
- Replace flexbox justify-between with relative positioning for GitHub icon
- Use absolute positioning to center GitHub icon on the page
- Remove empty balance div that was previously used for spacing
- Update comment to clarify GitHub logo is centered on page

BulkData page changes:
- Add minimum height (85px) and flexbox centering to code blocks
- Improve vertical alignment of code content within containers
- Add flex-col and justify-center classes for better content positioning
- Wrap code content in additional div for improved layout structure

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/d20297099941410ea76f12573adde4c2/neon-haven)

👀 [Preview Link](https://d20297099941410ea76f12573adde4c2-neon-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d20297099941410ea76f12573adde4c2</projectId>-->
<!--<branchName>neon-haven</branchName>-->