### PR TITLE
Add catch-all redirect to index.html in netlify.toml

### DIFF
--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -13,3 +13,8 @@
   from = "/api/*"
   status = 200
   to = "/.netlify/functions/api/:splat"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
Adds a new redirect rule to the Netlify configuration that catches all routes and redirects them to index.html with a 200 status code.

This redirect rule is added after the existing API redirect and will handle any routes that don't match the API pattern.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/d20297099941410ea76f12573adde4c2/orbit-space)

👀 [Preview Link](https://d20297099941410ea76f12573adde4c2-orbit-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d20297099941410ea76f12573adde4c2</projectId>-->
<!--<branchName>orbit-space</branchName>-->