### PR TITLE
Add dismissible site banner component

### DIFF
--- a/frontend/client/components/SiteBanner.tsx
+++ b/frontend/client/components/SiteBanner.tsx
@@ -22,11 +22,11 @@ export default function SiteBanner() {
   }
 
   return (
-    <div className="bg-amber-50 border-b border-amber-200">
+    <div className="bg-blue-50 border-b border-blue-200">
       <div className="max-w-9xl mx-auto px-7 py-3">
         <div className="flex items-center justify-between">
           <div className="flex-1 min-w-0">
-            <p className="text-sm text-amber-800">
+            <p className="text-sm text-blue-900">
               <span className="font-semibold">Notice</span>: This project is in
               the very early stages of its development. Site layout, API schema,
               data organization, and other features may change. Currently, we

--- a/frontend/client/components/SiteBanner.tsx
+++ b/frontend/client/components/SiteBanner.tsx
@@ -38,7 +38,7 @@ export default function SiteBanner() {
               variant="ghost"
               size="sm"
               onClick={handleDismiss}
-              className="text-amber-800 hover:text-amber-900 hover:bg-amber-100 p-1 h-auto"
+              className="text-blue-900 hover:text-blue-950 hover:bg-blue-100 p-1 h-auto"
             >
               <X className="w-4 h-4" />
               <span className="sr-only">Dismiss banner</span>

--- a/frontend/client/components/SiteBanner.tsx
+++ b/frontend/client/components/SiteBanner.tsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function SiteBanner() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const dismissed = localStorage.getItem("site-banner-dismissed");
+    if (!dismissed) {
+      setIsVisible(true);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+    localStorage.setItem("site-banner-dismissed", "true");
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div className="bg-amber-50 border-b border-amber-200">
+      <div className="max-w-9xl mx-auto px-7 py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-amber-800">
+              <span className="font-semibold">Notice</span>: This project is in
+              the very early stages of its development. Site layout, API schema,
+              data organization, and other features may change. Currently, we
+              expose only 45 sample agreements, as a proof-of-concept.
+            </p>
+          </div>
+          <div className="ml-4 flex-shrink-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleDismiss}
+              className="text-amber-800 hover:text-amber-900 hover:bg-amber-100 p-1 h-auto"
+            >
+              <X className="w-4 h-4" />
+              <span className="sr-only">Dismiss banner</span>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/client/components/SiteBanner.tsx
+++ b/frontend/client/components/SiteBanner.tsx
@@ -6,15 +6,25 @@ export default function SiteBanner() {
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
-    const dismissed = localStorage.getItem("site-banner-dismissed");
-    if (!dismissed) {
+    const dismissedTimestamp = localStorage.getItem("site-banner-dismissed");
+    if (!dismissedTimestamp) {
       setIsVisible(true);
+    } else {
+      const dismissedTime = parseInt(dismissedTimestamp);
+      const now = Date.now();
+      const oneDayInMs = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+
+      if (now - dismissedTime > oneDayInMs) {
+        // More than 24 hours have passed, show the banner again
+        setIsVisible(true);
+        localStorage.removeItem("site-banner-dismissed");
+      }
     }
   }, []);
 
   const handleDismiss = () => {
     setIsVisible(false);
-    localStorage.setItem("site-banner-dismissed", "true");
+    localStorage.setItem("site-banner-dismissed", Date.now().toString());
   };
 
   if (!isVisible) {

--- a/frontend/client/main.tsx
+++ b/frontend/client/main.tsx
@@ -14,6 +14,7 @@ import BulkData from "./pages/BulkData";
 import About from "./pages/About";
 import NotFound from "./pages/NotFound";
 import Footer from "./components/Footer";
+import SiteBanner from "./components/SiteBanner";
 
 const queryClient = new QueryClient();
 

--- a/frontend/client/main.tsx
+++ b/frontend/client/main.tsx
@@ -25,6 +25,7 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <div className="min-h-screen flex flex-col">
+          <SiteBanner />
           <main className="flex-1">
             <Routes>
               <Route path="/" element={<Landing />} />


### PR DESCRIPTION
Creates a new SiteBanner component that displays a notice about the project being in early development stages.

The banner includes:
- Blue-themed styling with notice text about early development status
- Dismissible functionality with X button
- Local storage persistence that remembers dismissal for 24 hours
- Automatic re-display after 24 hours have passed
- Responsive layout with proper spacing and accessibility

The component is imported and rendered at the top of the main application layout above the main content area.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/d20297099941410ea76f12573adde4c2/aura-oasis)

👀 [Preview Link](https://d20297099941410ea76f12573adde4c2-aura-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d20297099941410ea76f12573adde4c2</projectId>-->
<!--<branchName>aura-oasis</branchName>-->