### PR TITLE
Add download size display to BulkData table

### DIFF
--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -357,7 +357,8 @@ export default function BulkData() {
                       <td className="px-6 py-4">
                         <div className="flex items-center space-x-2">
                           <span className="font-mono text-sm text-material-text-secondary truncate max-w-xs">
-                            {dump.sha256}
+                            {dump.sha256.substring(0, dump.sha256.length - 20)}
+                            ...
                           </span>
                           <button
                             onClick={() =>
@@ -373,6 +374,11 @@ export default function BulkData() {
                             )}
                           </button>
                         </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span className="text-sm text-material-text-secondary">
+                          {formatSize(dump.size_bytes)}
+                        </span>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
                         <div className="flex space-x-2">

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -8,6 +8,7 @@ interface DumpInfo {
   sha256: string;
   sql: string;
   timestamp: string;
+  size_bytes?: number;
 }
 
 export default function BulkData() {

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -325,6 +325,9 @@ export default function BulkData() {
                       SHA256 Hash
                     </th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-material-text-secondary uppercase tracking-wider">
+                      Download Size
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-material-text-secondary uppercase tracking-wider">
                       Actions
                     </th>
                   </tr>

--- a/frontend/client/pages/BulkData.tsx
+++ b/frontend/client/pages/BulkData.tsx
@@ -104,6 +104,12 @@ export default function BulkData() {
     return timestamp;
   };
 
+  const formatSize = (bytes?: number): string => {
+    if (!bytes) return "—";
+    const megabytes = bytes / (1024 * 1024);
+    return `${megabytes.toFixed(1)} MB`;
+  };
+
   const copyToClipboard = (text: string, id: string) => {
     const textArea = document.createElement("textarea");
     textArea.value = text;


### PR DESCRIPTION
Add download size information to the BulkData page table.

Changes made:
- Add optional `size_bytes` field to DumpInfo interface
- Fetch size information from manifest files for each dump
- Add new "Download Size" column to the table
- Implement `formatSize` helper function to display sizes in MB format
- Truncate SHA256 hash display with ellipsis for better table layout
- Handle manifest fetch errors gracefully with console warnings

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/d20297099941410ea76f12573adde4c2/quantum-haven)

👀 [Preview Link](https://d20297099941410ea76f12573adde4c2-quantum-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d20297099941410ea76f12573adde4c2</projectId>-->
<!--<branchName>quantum-haven</branchName>-->