### PR TITLE
Refresh About page with hero band, quick facts, cards, and TOC

### DIFF
--- a/backend/routes/agreements.py
+++ b/backend/routes/agreements.py
@@ -11,6 +11,7 @@ from flask import Flask, Response, abort, current_app, g, jsonify, request
 from flask.views import MethodView
 from flask_smorest import Blueprint
 from sqlalchemy import and_, asc, bindparam, desc, func, or_, text
+from sqlalchemy.exc import SQLAlchemyError
 
 from backend.counsel_leaderboards import build_counsel_leaderboards_from_summary_rows
 from backend.filtering import (
@@ -1829,19 +1830,42 @@ def register_agreements_routes(
                 """
             )
         ).mappings().first()
+        try:
+            overview_row = db.session.execute(
+                text(
+                    f"""
+                    SELECT latest_filing_date
+                    FROM {deps._schema_prefix()}agreement_overview_summary
+                    LIMIT 1
+                    """
+                )
+            ).mappings().first()
+        except SQLAlchemyError:
+            overview_row = None
 
         row_dict = deps._row_mapping_as_dict(cast(object, row)) if row is not None else {}
-        payload: dict[str, int] = {
+        overview_row_dict = (
+            deps._row_mapping_as_dict(cast(object, overview_row))
+            if overview_row is not None
+            else {}
+        )
+        latest_filing_date = overview_row_dict.get("latest_filing_date")
+        if isinstance(latest_filing_date, (date, datetime)):
+            latest_filing_date = latest_filing_date.isoformat()
+        elif latest_filing_date is not None:
+            latest_filing_date = str(latest_filing_date)
+        payload: dict[str, object] = {
             "agreements": deps._to_int(cast(object, row_dict.get("agreements"))),
             "sections": deps._to_int(cast(object, row_dict.get("sections"))),
             "pages": deps._to_int(cast(object, row_dict.get("pages"))),
+            "latest_filing_date": latest_filing_date,
         }
         with deps._agreements_summary_lock:
             deps._agreements_summary_cache["payload"] = payload
             deps._agreements_summary_cache["ts"] = now
 
         return _cacheable_json_response(
-            cast(dict[str, object], payload),
+            payload,
             max_age=deps._AGREEMENTS_SUMMARY_TTL_SECONDS,
         )
 

--- a/backend/tests/test_main_routes.py
+++ b/backend/tests/test_main_routes.py
@@ -303,6 +303,20 @@ class MainRoutesTests(unittest.TestCase):
                 )
                 conn.execute(
                     text(
+                        "CREATE TABLE IF NOT EXISTS summary_data ("
+                        "count_agreements INTEGER NOT NULL, "
+                        "count_sections INTEGER NOT NULL, "
+                        "count_pages INTEGER NOT NULL)"
+                    )
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO summary_data (count_agreements, count_sections, count_pages) "
+                        "VALUES (4, 3, 12)"
+                    )
+                )
+                conn.execute(
+                    text(
                         "INSERT INTO agreement_deal_type_summary (year, deal_type, count) VALUES "
                         "(2020, 'merger', 1), "
                         "(2021, 'stock_acquisition', 2)"
@@ -608,6 +622,40 @@ class MainRoutesTests(unittest.TestCase):
         self.assertEqual(body.get("total_count"), 2)
         self.assertEqual(body.get("total_pages"), 1)
         self.assertEqual(len(body.get("results", [])), 2)
+
+    def test_agreements_summary_includes_latest_filing_date(self):
+        self.app_module._agreements_summary_cache["payload"] = None
+        self.app_module._agreements_summary_cache["ts"] = 0
+        with self.app.app_context():
+            engine = self.app_module.db.engine
+            with engine.begin() as conn:
+                conn.execute(
+                    text(
+                        "CREATE TABLE IF NOT EXISTS agreement_overview_summary ("
+                        "singleton_key INTEGER NOT NULL PRIMARY KEY, "
+                        "metadata_covered_agreements INTEGER NULL, "
+                        "metadata_coverage_pct REAL NULL, "
+                        "taxonomy_covered_sections INTEGER NULL, "
+                        "taxonomy_coverage_pct REAL NULL, "
+                        "latest_filing_date TEXT NULL)"
+                    )
+                )
+                conn.execute(text("DELETE FROM agreement_overview_summary"))
+                conn.execute(
+                    text(
+                        "INSERT INTO agreement_overview_summary "
+                        "(singleton_key, metadata_covered_agreements, metadata_coverage_pct, taxonomy_covered_sections, taxonomy_coverage_pct, latest_filing_date) VALUES "
+                        "(1, 123, 61.5, 4567, 87.2, '2023-04-01')"
+                    )
+                )
+        client = self.app.test_client()
+        res = client.get("/v1/agreements-summary")
+        self.assertEqual(res.status_code, 200)
+        body = res.get_json()
+        self.assertEqual(body.get("agreements"), 4)
+        self.assertEqual(body.get("sections"), 3)
+        self.assertEqual(body.get("pages"), 12)
+        self.assertEqual(body.get("latest_filing_date"), "2023-04-01")
 
     def test_agreements_bulk_cursor_pagination(self):
         client = self.app.test_client()

--- a/frontend/client/components/AppLayout.tsx
+++ b/frontend/client/components/AppLayout.tsx
@@ -97,7 +97,7 @@ export function AppLayout() {
         id="main-content"
         role="main"
         tabIndex={-1}
-        className="flex-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        className="flex-1 outline-none"
       >
         <Suspense fallback={<RouteFallback />}>
           <Outlet />

--- a/frontend/client/hooks/use-agreement-summary.ts
+++ b/frontend/client/hooks/use-agreement-summary.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import { apiUrl } from "@/lib/api-config";
+import { authFetch } from "@/lib/auth-fetch";
+import { readSessionCache, writeSessionCache } from "@/lib/session-cache";
+
+export type AgreementSummary = {
+  agreements: number;
+  sections: number;
+  pages: number;
+  latest_filing_date: string | null;
+};
+
+const AGREEMENT_SUMMARY_CACHE_KEY = "agreement-index-summary:v2";
+const AGREEMENT_SUMMARY_CACHE_TTL_MS = 5 * 60 * 1000;
+
+export function useAgreementSummary() {
+  const [summary, setSummary] = useState<AgreementSummary | null>(() =>
+    readSessionCache<AgreementSummary>(
+      AGREEMENT_SUMMARY_CACHE_KEY,
+      AGREEMENT_SUMMARY_CACHE_TTL_MS,
+    ),
+  );
+  const [isLoading, setIsLoading] = useState(summary === null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (summary !== null) return;
+
+    let cancelled = false;
+    let timeoutId: number | null = null;
+    let idleId: number | null = null;
+
+    const fetchSummary = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const res = await authFetch(apiUrl("v1/agreements-summary"));
+        if (!res.ok) {
+          throw new Error(`Summary request failed (${res.status})`);
+        }
+        const data = (await res.json()) as AgreementSummary;
+        if (!cancelled) {
+          setSummary(data);
+          writeSessionCache(AGREEMENT_SUMMARY_CACHE_KEY, data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Unable to load agreement summary.",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    const scheduleFetch = () => {
+      if (!cancelled) {
+        void fetchSummary();
+      }
+    };
+
+    const browserWindow = typeof window !== "undefined" ? window : null;
+
+    if (browserWindow && "requestIdleCallback" in browserWindow) {
+      idleId = browserWindow.requestIdleCallback(scheduleFetch, {
+        timeout: 1500,
+      });
+    } else {
+      timeoutId = window.setTimeout(scheduleFetch, 800);
+    }
+
+    return () => {
+      cancelled = true;
+      if (
+        idleId !== null &&
+        browserWindow &&
+        "cancelIdleCallback" in browserWindow
+      ) {
+        browserWindow.cancelIdleCallback(idleId);
+      }
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [summary]);
+
+  return {
+    summary,
+    isLoading,
+    error,
+  };
+}

--- a/frontend/client/pages/About.tsx
+++ b/frontend/client/pages/About.tsx
@@ -1,220 +1,437 @@
+import { useEffect, useState } from "react";
+import {
+  Accessibility,
+  CalendarClock,
+  Cpu,
+  ExternalLink,
+  FileCode2,
+  Github,
+  LineChart,
+  ListTree,
+  Plug,
+  Search,
+  Shield,
+  Tags,
+} from "lucide-react";
 import { PageShell } from "@/components/PageShell";
 
+const docsUrl = "https://docs.pandects.org/docs/guides/getting-started";
+
+const SECTION_IDS = ["overview", "contributing", "credits"] as const;
+type SectionId = (typeof SECTION_IDS)[number];
+
+const quickFacts = [
+  { icon: CalendarClock, eyebrow: "Cadence", value: "Monthly refresh" },
+  { icon: FileCode2, eyebrow: "Format", value: "XML + taxonomy" },
+  { icon: Plug, eyebrow: "Access", value: "Free API + MCP" },
+  { icon: Github, eyebrow: "Source", value: "Open source" },
+];
+
+const helpAreas = [
+  {
+    icon: Shield,
+    title: "Security hardening",
+    description: "Including OAuth flow reviews.",
+  },
+  {
+    icon: Accessibility,
+    title: "Accessibility",
+    description: "Keyboard, focus, contrast.",
+  },
+  {
+    icon: Cpu,
+    title: "ML model optimization",
+    description: "Performance and quality.",
+  },
+];
+
+const roadmapItems: {
+  icon: typeof Tags;
+  title: string;
+  description?: string;
+}[] = [
+  {
+    icon: Tags,
+    title: "Taxonomize clauses broadly",
+    description:
+      "Not just tax — important clauses generally. Today we taxonomize sections, but a single section can contain multiple important clauses.",
+  },
+  {
+    icon: Search,
+    title: "Defined terms",
+    description:
+      "Identify them (including those in appendices) and make them searchable.",
+  },
+  {
+    icon: LineChart,
+    title: "'Is this market?'",
+    description:
+      "A specific UI surface to help practitioners answer market questions.",
+  },
+  {
+    icon: ListTree,
+    title: "Refine the section taxonomy",
+  },
+];
+
+const tocItems: { id: SectionId; label: string }[] = [
+  { id: "overview", label: "01 · Overview" },
+  { id: "contributing", label: "02 · Contributing" },
+  { id: "credits", label: "03 · Credits" },
+];
+
+const extIcon = (
+  <ExternalLink
+    className="ml-0.5 inline-block h-3 w-3 align-baseline opacity-60"
+    aria-hidden="true"
+  />
+);
+
 export default function About() {
-  const docsUrl = "https://docs.pandects.org/docs/guides/getting-started";
+  const [activeId, setActiveId] = useState<SectionId>("overview");
+
+  useEffect(() => {
+    const elements = SECTION_IDS.map((id) =>
+      document.getElementById(id),
+    ).filter((el): el is HTMLElement => el !== null);
+
+    if (elements.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const intersecting = entries.filter((e) => e.isIntersecting);
+        if (intersecting.length === 0) return;
+        const topmost = intersecting.reduce((a, b) =>
+          a.boundingClientRect.top < b.boundingClientRect.top ? a : b,
+        );
+        setActiveId(topmost.target.id as SectionId);
+      },
+      { threshold: [0, 0.25, 0.5] },
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <PageShell size="xl" title="About">
-      <article className="space-y-12">
-        <section
-          id="overview"
-          className="scroll-mt-24 space-y-4 border-t border-border pt-6"
-          aria-labelledby="overview-heading"
-        >
-          <h2
-            id="overview-heading"
-            className="text-2xl font-semibold tracking-tight text-foreground"
-          >
-            Overview
-          </h2>
-          <p className="prose prose-copy max-w-none">
-            Pandects is an <strong>open-source M&A research platform</strong>{" "}
-            built to make it easier to browse and analyze sections across
-            definitive merger agreements. Unlike other corpora, we update our
-            database on a <strong>monthly basis</strong>, and make available not
-            just EDGAR URLs or unprocessed HTML, but also <strong>XML</strong>,
-            compiled with purpose-built ML and data orchestration pipelines. On
-            top of exposing XML, we <strong>taxonomize</strong> each section of
-            each agreement into a comprehensive taxonomy, and enrich each deal
-            with detailed metadata.
-          </p>
-          <p className="prose prose-copy max-w-none">
-            While we expose a web-based search interface, the real power of the
-            Pandects platform lies in the <strong>API </strong>and associated{" "}
-            <strong>MCP server</strong>. By creating a free account, you gain
-            access to unredacted XML and unlock higher rate limits for public
-            endpoints, putting Pandects data at your fingertips. An account also
-            provides access to the MCP server, enabling you to tackle research
-            questions by partnering with an AI research agent of your choice. To
-            aid adoption of both the API and MCP server, we've put together a
-            small collection of{" "}
-            <a
-              href="https://github.com/PlatosTwin/pandects-app/tree/main/examples"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="GitHub directory of API examples (opens in a new tab)"
-              className="underline underline-offset-2"
-            >
-              Jupyter Notebook examples
-            </a>{" "}
-            as well as built out a{" "}
-            <a
-              href={docsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Documentation site (opens in a new tab)"
-              className="underline underline-offset-2"
-            >
-              documentation site
-            </a>
-            . Finally, for more control, users may elect to{" "}
-            <a
-              href="https://pandects.org/bulk-data/"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Bulk data download page (opens in a new tab)"
-              className="underline underline-offset-2"
-            >
-              bulk download
-            </a>{" "}
-            a copy of the complete database.
-          </p>
-        </section>
-
-        <section
-          id="contributing"
-          className="scroll-mt-24 space-y-4 border-t border-border pt-6"
-          aria-labelledby="contributing-heading"
-        >
-          <h2
-            id="contributing-heading"
-            className="text-2xl font-semibold tracking-tight text-foreground"
-          >
-            Contributing
-          </h2>
-          <p className="prose prose-copy max-w-none">
-            This is an open-source project, and contributions are welcome. See
-            the{" "}
-            <a
-              href="https://github.com/PlatosTwin/pandects-app"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="GitHub repository (opens in a new tab)"
-              className="underline underline-offset-2"
-            >
-              GitHub repository
-            </a>{" "}
-            for details.
-          </p>
-          <p className="prose-copy">
-            We are especially thankful for focused contributions to:
-          </p>
-          <ul className="prose-copy list-disc space-y-2 pl-6">
-            <li>Security hardening, including OAuth flow reviews.</li>
-            <li>Accessibility improvements (keyboard, focus, contrast).</li>
-            <li>ML model optimization.</li>
-          </ul>
-          <p className="prose-copy">
-            In the medium term, we hope to:
-          </p>
-          <ul className="prose-copy list-disc space-y-2 pl-6">
-            <li>
-              Taxonomize not just <em>tax</em> clauses but also important
-              clauses <em>generally</em>. Right now, in addition to tax clauses,
-              we taxonomize <em>sections</em>, but a single section can have
-              multiple important clauses within it.
-            </li>
-            <li>
-              Identify defined terms, including those relegated to appendices,
-              and make them searchable.
-            </li>
-            <li>
-              Develop a specific UI surface to help practitioners answer, "Is
-              this market?" or "What is market?" questions.
-            </li>
-            <li>Refine the section taxonomy.</li>
-          </ul>
-        </section>
-
-        <section
-          id="credits"
-          className="scroll-mt-24 space-y-4 border-t border-border pt-6"
-          aria-labelledby="credits-heading"
-        >
-          <h2
-            id="credits-heading"
-            className="text-2xl font-semibold tracking-tight text-foreground"
-          >
-            Credits
-          </h2>
-          <div className="space-y-6 text-muted-foreground">
-            <p className="prose prose-copy max-w-none">
-              Professor Emiliano Catan at NYU Law has been an active advisor to
-              this project from the beginning. The{" "}
-              <a
-                href="https://www.law.nyu.edu/leadershipprogram"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Jacobson Leadership Program in Law and Business (opens in a new tab)"
-                className="underline underline-offset-2"
-              >
-                Jacobson Leadership Program in Law and Business
-              </a>{" "}
-              at NYU has also provided support, including a commitment to all of
-              the startup funding. NYU Law professor Alex Walker developed the
-              tax taxonomy, for which we are very thankful. We are also thankful
-              to NYU Law professor Chris Sprigman. The concept and design for
-              this site borrow heavily from the{" "}
-              <a
-                href="https://case.law"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Caselaw Access Project (opens in a new tab)"
-                className="underline underline-offset-2"
-              >
-                Caselaw Access Project
-              </a>
-              , a product of the{" "}
-              <a
-                href="https://lil.law.harvard.edu/"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Library Innovation Lab (opens in a new tab)"
-                className="underline underline-offset-2"
-              >
-                Library Innovation Lab
-              </a>{" "}
-              (LIL) at Harvard Law; Jack Cushman at LIL provided guidance and
-              advice early on in this project. Josh Carty provided technical
-              assistance early on, and helped brainstorm.
+      <div className="lg:grid lg:grid-cols-[1fr_180px] lg:gap-12">
+        <article>
+          <div>
+            <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+              PROJECT · ABOUT
+            </div>
+            <p className="mt-3 text-lg text-muted-foreground max-w-[68ch]">
+              An open-source M&amp;A research platform — XML, taxonomy, API,
+              and MCP server over definitive merger agreements.
             </p>
-            <p className="prose prose-copy max-w-none">
-              This project would not have gotten off the ground without the
-              prior work of Peter Adelson, Matthew Jennejohn, Julian Nyarko, and
-              Eric Talley, whose{" "}
-              <a
-                href="https://onlinelibrary.wiley.com/doi/abs/10.1111/jels.12410"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Introducing a New Corpus of Definitive M&A Agreements, 2000–2020 (opens in a new tab)"
-                className="underline underline-offset-2"
-              >
-                <em>
-                  Introducing a New Corpus of Definitive M&A Agreements,
-                  2000–2020
-                </em>
-              </a>{" "}
-              provided the inspiration and seed set of source links to
-              definitive agreements in EDGAR. Their GitHub repository is
-              available{" "}
-              <a
-                href="https://github.com/padelson/dma_corpus/tree/main"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="DMA corpus repository (opens in a new tab)"
-                className="underline underline-offset-2"
-              >
-                DMA corpus repository
-              </a>
-              .
-            </p>
-            <p className="prose prose-copy max-w-none">
-              Finally, this project was supported in part through NYU IT High
-              Performance Computing resources, services, and staff expertise.
-            </p>
+            <div className="mt-6 h-px w-12 bg-primary/70" />
           </div>
-        </section>
-      </article>
+
+          <section
+            id="overview"
+            className="scroll-mt-24 first:pt-0 pt-12"
+            aria-labelledby="overview-heading"
+          >
+            <div className="flex items-center gap-3">
+              <span className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-primary/10 text-primary text-xs font-medium tabular-nums">
+                01
+              </span>
+              <h2
+                id="overview-heading"
+                className="text-2xl font-semibold tracking-tight text-foreground"
+              >
+                Overview
+              </h2>
+            </div>
+
+            <div className="mt-6 grid grid-cols-2 lg:grid-cols-4 gap-3">
+              {quickFacts.map(({ icon: Icon, eyebrow, value }) => (
+                <div
+                  key={eyebrow}
+                  className="rounded-lg border border-border bg-card p-4"
+                >
+                  <Icon className="h-5 w-5 text-primary mb-2" />
+                  <div className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                    {eyebrow}
+                  </div>
+                  <div className="text-sm font-medium text-foreground mt-1">
+                    {value}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <p className="prose prose-copy max-w-[68ch] mt-6">
+              Pandects is an <strong>open-source M&A research platform</strong>{" "}
+              built to make it easier to browse and analyze sections across
+              definitive merger agreements. Unlike other corpora, we update our
+              database on a <strong>monthly basis</strong>, and make available
+              not just EDGAR URLs or unprocessed HTML, but also{" "}
+              <strong>XML</strong>, compiled with purpose-built ML and data
+              orchestration pipelines. On top of exposing XML, we{" "}
+              <strong>taxonomize</strong> each section of each agreement into a
+              comprehensive taxonomy, and enrich each deal with detailed
+              metadata.
+            </p>
+            <p className="prose prose-copy max-w-[68ch] mt-4">
+              While we expose a web-based search interface, the real power of
+              the Pandects platform lies in the <strong>API </strong>and
+              associated <strong>MCP server</strong>. By creating a free
+              account, you gain access to unredacted XML and unlock higher rate
+              limits for public endpoints, putting Pandects data at your
+              fingertips. An account also provides access to the MCP server,
+              enabling you to tackle research questions by partnering with an
+              AI research agent of your choice. To aid adoption of both the API
+              and MCP server, we've put together a small collection of{" "}
+              <a
+                href="https://github.com/PlatosTwin/pandects-app/tree/main/examples"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="GitHub directory of API examples (opens in a new tab)"
+                className="underline underline-offset-2"
+              >
+                Jupyter Notebook examples
+                {extIcon}
+              </a>{" "}
+              as well as built out a{" "}
+              <a
+                href={docsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Documentation site (opens in a new tab)"
+                className="underline underline-offset-2"
+              >
+                documentation site
+                {extIcon}
+              </a>
+              . Finally, for more control, users may elect to{" "}
+              <a
+                href="https://pandects.org/bulk-data/"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Bulk data download page (opens in a new tab)"
+                className="underline underline-offset-2"
+              >
+                bulk download
+                {extIcon}
+              </a>{" "}
+              a copy of the complete database.
+            </p>
+          </section>
+
+          <section
+            id="contributing"
+            className="scroll-mt-24 pt-12"
+            aria-labelledby="contributing-heading"
+          >
+            <div className="flex items-center gap-3">
+              <span className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-primary/10 text-primary text-xs font-medium tabular-nums">
+                02
+              </span>
+              <h2
+                id="contributing-heading"
+                className="text-2xl font-semibold tracking-tight text-foreground"
+              >
+                Contributing
+              </h2>
+            </div>
+
+            <p className="prose prose-copy max-w-[68ch] mt-6">
+              This is an open-source project, and contributions are welcome.
+              See the{" "}
+              <a
+                href="https://github.com/PlatosTwin/pandects-app"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="GitHub repository (opens in a new tab)"
+                className="underline underline-offset-2"
+              >
+                GitHub repository
+                {extIcon}
+              </a>{" "}
+              for details.
+            </p>
+
+            <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-muted-foreground mt-8">
+              Where help is most welcome
+            </h3>
+            <div className="mt-3 grid grid-cols-1 md:grid-cols-3 gap-3">
+              {helpAreas.map(({ icon: Icon, title, description }) => (
+                <div
+                  key={title}
+                  className="rounded-lg border border-border bg-card p-4"
+                >
+                  <Icon className="h-5 w-5 text-primary mb-2" />
+                  <h4 className="text-base font-medium text-foreground">
+                    {title}
+                  </h4>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {description}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-muted-foreground mt-8">
+              On the roadmap
+            </h3>
+            <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
+              {roadmapItems.map(({ icon: Icon, title, description }) => (
+                <div
+                  key={title}
+                  className="rounded-lg border border-border bg-card p-4"
+                >
+                  <Icon className="h-5 w-5 text-primary mb-2" />
+                  <h4 className="text-base font-medium text-foreground">
+                    {title}
+                  </h4>
+                  {description && (
+                    <p className="text-sm text-muted-foreground mt-1">
+                      {description}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section
+            id="credits"
+            className="scroll-mt-24 pt-12"
+            aria-labelledby="credits-heading"
+          >
+            <div className="flex items-center gap-3">
+              <span className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-primary/10 text-primary text-xs font-medium tabular-nums">
+                03
+              </span>
+              <h2
+                id="credits-heading"
+                className="text-2xl font-semibold tracking-tight text-foreground"
+              >
+                Credits
+              </h2>
+            </div>
+
+            <dl className="mt-6 grid grid-cols-1 sm:grid-cols-[160px_1fr] gap-x-6 gap-y-5">
+              <dt className="text-xs uppercase tracking-[0.12em] text-muted-foreground self-start">
+                Advisors
+              </dt>
+              <dd className="text-sm text-foreground">
+                Emiliano Catan (NYU Law); Alex Walker (NYU Law, tax taxonomy);
+                Chris Sprigman (NYU Law).
+              </dd>
+
+              <dt className="text-xs uppercase tracking-[0.12em] text-muted-foreground self-start">
+                Institutional support
+              </dt>
+              <dd className="text-sm text-foreground">
+                <a
+                  href="https://www.law.nyu.edu/leadershipprogram"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Jacobson Leadership Program in Law and Business (opens in a new tab)"
+                  className="underline underline-offset-2"
+                >
+                  Jacobson Leadership Program in Law and Business
+                  {extIcon}
+                </a>
+                ; NYU IT High Performance Computing.
+              </dd>
+
+              <dt className="text-xs uppercase tracking-[0.12em] text-muted-foreground self-start">
+                Inspiration
+              </dt>
+              <dd className="text-sm text-foreground">
+                Site concept and design borrow from{" "}
+                <a
+                  href="https://case.law"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Caselaw Access Project (opens in a new tab)"
+                  className="underline underline-offset-2"
+                >
+                  Caselaw Access Project
+                  {extIcon}
+                </a>
+                , a product of the{" "}
+                <a
+                  href="https://lil.law.harvard.edu/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Library Innovation Lab (opens in a new tab)"
+                  className="underline underline-offset-2"
+                >
+                  Library Innovation Lab
+                  {extIcon}
+                </a>{" "}
+                (LIL) at Harvard Law. Jack Cushman at LIL provided early
+                guidance.
+              </dd>
+
+              <dt className="text-xs uppercase tracking-[0.12em] text-muted-foreground self-start">
+                Prior work
+              </dt>
+              <dd className="text-sm text-foreground">
+                Peter Adelson, Matthew Jennejohn, Julian Nyarko, Eric Talley —{" "}
+                <a
+                  href="https://onlinelibrary.wiley.com/doi/abs/10.1111/jels.12410"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Introducing a New Corpus of Definitive M&A Agreements, 2000–2020 (opens in a new tab)"
+                  className="underline underline-offset-2"
+                >
+                  <em>
+                    Introducing a New Corpus of Definitive M&A Agreements,
+                    2000–2020
+                  </em>
+                  {extIcon}
+                </a>
+                .{" "}
+                <a
+                  href="https://github.com/padelson/dma_corpus/tree/main"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="DMA corpus repository (opens in a new tab)"
+                  className="underline underline-offset-2"
+                >
+                  DMA corpus repository
+                  {extIcon}
+                </a>
+                .
+              </dd>
+
+              <dt className="text-xs uppercase tracking-[0.12em] text-muted-foreground self-start">
+                Technical assistance
+              </dt>
+              <dd className="text-sm text-foreground">
+                Josh Carty (early help and brainstorming).
+              </dd>
+            </dl>
+          </section>
+        </article>
+
+        <aside className="hidden lg:block">
+          <nav className="sticky top-24 text-xs">
+            {tocItems.map(({ id, label }) => {
+              const active = activeId === id;
+              return (
+                <a
+                  key={id}
+                  href={`#${id}`}
+                  className={
+                    active
+                      ? "block py-1 transition-colors text-primary font-medium border-l-2 border-primary pl-2 -ml-2"
+                      : "block py-1 text-muted-foreground hover:text-foreground transition-colors"
+                  }
+                >
+                  {label}
+                </a>
+              );
+            })}
+          </nav>
+        </aside>
+      </div>
     </PageShell>
   );
 }

--- a/frontend/client/pages/About.tsx
+++ b/frontend/client/pages/About.tsx
@@ -1,31 +1,92 @@
-import { useEffect, useState } from "react";
 import {
-  Accessibility,
+  ArrowRight,
+  BookOpen,
   CalendarClock,
   Cpu,
   ExternalLink,
   FileCode2,
-  Github,
+  FileText,
   LineChart,
+  Layers,
   ListTree,
   Plug,
   Search,
   Shield,
   Tags,
 } from "lucide-react";
+import type { SVGProps } from "react";
 import { PageShell } from "@/components/PageShell";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAgreementSummary } from "@/hooks/use-agreement-summary";
+import { formatDateValue } from "@/lib/format-utils";
+import { Link } from "react-router-dom";
 
 const docsUrl = "https://docs.pandects.org/docs/guides/getting-started";
 
-const SECTION_IDS = ["overview", "contributing", "credits"] as const;
-type SectionId = (typeof SECTION_IDS)[number];
+function A11ySymbol(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <circle cx="12" cy="12" r="9" />
+      <circle cx="12" cy="7" r="1" />
+      <path d="M7.5 10h9" />
+      <path d="M12 10v3.5" />
+      <path d="m9.5 18 2.5-4.5 2.5 4.5" />
+    </svg>
+  );
+}
 
 const quickFacts = [
-  { icon: CalendarClock, eyebrow: "Cadence", value: "Monthly refresh" },
-  { icon: FileCode2, eyebrow: "Format", value: "XML + taxonomy" },
-  { icon: Plug, eyebrow: "Access", value: "Free API + MCP" },
-  { icon: Github, eyebrow: "Source", value: "Open source" },
+  {
+    icon: FileText,
+    eyebrow: "Coverage",
+    value: "Definitive merger agreements",
+  },
+  {
+    icon: FileCode2,
+    eyebrow: "Structure",
+    value: "XML",
+  },
+  {
+    icon: Plug,
+    eyebrow: "Access",
+    value: "UI Search, API, MCP, bulk",
+  },
+  {
+    icon: CalendarClock,
+    eyebrow: "Cadence",
+    value: "Monthly refresh",
+  },
 ];
+
+const corpusMetrics = [
+  {
+    key: "agreements",
+    icon: FileText,
+    label: "Agreements",
+    detail: "Ingested",
+  },
+  {
+    key: "sections",
+    icon: Layers,
+    label: "Sections",
+    detail: "Indexed",
+  },
+  {
+    key: "pages",
+    icon: BookOpen,
+    label: "Pages",
+    detail: "Parsed",
+  },
+] as const;
 
 const helpAreas = [
   {
@@ -34,7 +95,7 @@ const helpAreas = [
     description: "Including OAuth flow reviews.",
   },
   {
-    icon: Accessibility,
+    icon: A11ySymbol,
     title: "Accessibility",
     description: "Keyboard, focus, contrast.",
   },
@@ -74,12 +135,6 @@ const roadmapItems: {
   },
 ];
 
-const tocItems: { id: SectionId; label: string }[] = [
-  { id: "overview", label: "01 · Overview" },
-  { id: "contributing", label: "02 · Contributing" },
-  { id: "credits", label: "03 · Credits" },
-];
-
 const extIcon = (
   <ExternalLink
     className="ml-0.5 inline-block h-3 w-3 align-baseline opacity-60"
@@ -88,46 +143,23 @@ const extIcon = (
 );
 
 export default function About() {
-  const [activeId, setActiveId] = useState<SectionId>("overview");
-
-  useEffect(() => {
-    const elements = SECTION_IDS.map((id) =>
-      document.getElementById(id),
-    ).filter((el): el is HTMLElement => el !== null);
-
-    if (elements.length === 0) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const intersecting = entries.filter((e) => e.isIntersecting);
-        if (intersecting.length === 0) return;
-        const topmost = intersecting.reduce((a, b) =>
-          a.boundingClientRect.top < b.boundingClientRect.top ? a : b,
-        );
-        setActiveId(topmost.target.id as SectionId);
-      },
-      { threshold: [0, 0.25, 0.5] },
-    );
-
-    elements.forEach((el) => observer.observe(el));
-    return () => observer.disconnect();
-  }, []);
+  const {
+    summary,
+    isLoading: summaryLoading,
+    error: summaryError,
+  } = useAgreementSummary();
+  const latestFilingDate =
+    summary?.latest_filing_date && !summaryError
+      ? formatDateValue(summary.latest_filing_date)
+      : null;
+  const coverageValue = latestFilingDate
+    ? `Jan. 1, 2000 - ${latestFilingDate}`
+    : "Since Jan. 1, 2000";
 
   return (
-    <PageShell size="xl" title="About">
-      <div className="lg:grid lg:grid-cols-[1fr_180px] lg:gap-12">
+    <PageShell size="lg" title="About">
+      <div className="w-full">
         <article>
-          <div>
-            <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
-              PROJECT · ABOUT
-            </div>
-            <p className="mt-3 text-lg text-muted-foreground max-w-[68ch]">
-              An open-source M&amp;A research platform — XML, taxonomy, API,
-              and MCP server over definitive merger agreements.
-            </p>
-            <div className="mt-6 h-px w-12 bg-primary/70" />
-          </div>
-
           <section
             id="overview"
             className="scroll-mt-24 first:pt-0 pt-12"
@@ -145,7 +177,7 @@ export default function About() {
               </h2>
             </div>
 
-            <div className="mt-6 grid grid-cols-2 lg:grid-cols-4 gap-3">
+            <div className="mt-6 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
               {quickFacts.map(({ icon: Icon, eyebrow, value }) => (
                 <div
                   key={eyebrow}
@@ -155,14 +187,71 @@ export default function About() {
                   <div className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
                     {eyebrow}
                   </div>
-                  <div className="text-sm font-medium text-foreground mt-1">
-                    {value}
+                  <div className="mt-1 text-sm font-medium leading-5 text-foreground">
+                    {eyebrow === "Coverage" ? coverageValue : value}
                   </div>
                 </div>
               ))}
             </div>
 
-            <p className="prose prose-copy max-w-[68ch] mt-6">
+            <div className="mt-4 rounded-lg border border-border bg-card p-4 shadow-sm sm:p-5">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div className="max-w-2xl">
+                  <div className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                    Agreement Index
+                  </div>
+                  <p className="mt-1 text-sm prose-copy">
+                    Browse the corpus by year, party, and processing status.
+                  </p>
+                </div>
+                <Link
+                  to="/agreement-index"
+                  className="inline-flex w-fit items-center gap-2 rounded-md border border-primary/30 bg-primary/10 px-3 py-2 text-sm font-medium text-primary transition-colors hover:border-primary/50 hover:bg-primary/15"
+                >
+                  Browse the index
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+              </div>
+
+              {!summaryError && (
+                <div
+                  className="mt-4 grid gap-3 md:grid-cols-3"
+                  aria-busy={summaryLoading}
+                  aria-live="polite"
+                >
+                  {corpusMetrics.map(({ key, icon: Icon, label, detail }) => (
+                    <div
+                      key={key}
+                      className="flex min-h-[5.5rem] items-center gap-3 rounded-md border border-border bg-background/80 p-3"
+                    >
+                      <div className="flex h-9 w-9 flex-none items-center justify-center rounded-md bg-primary/10 text-primary">
+                        <Icon className="h-4 w-4" aria-hidden="true" />
+                      </div>
+                      <div className="min-w-0">
+                        <div className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                          {label}
+                        </div>
+                        <div className="flex min-h-7 items-center text-xl font-semibold tabular-nums text-foreground">
+                          {summaryLoading ? (
+                            <>
+                              <Skeleton className="h-6 w-20" />
+                              <span className="sr-only">Loading {label}</span>
+                            </>
+                          ) : (
+                            (summary?.[key] ?? 0).toLocaleString("en-US")
+                          )}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {detail}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <p className="prose-copy mt-6">
               Pandects is an <strong>open-source M&A research platform</strong>{" "}
               built to make it easier to browse and analyze sections across
               definitive merger agreements. Unlike other corpora, we update our
@@ -174,7 +263,7 @@ export default function About() {
               comprehensive taxonomy, and enrich each deal with detailed
               metadata.
             </p>
-            <p className="prose prose-copy max-w-[68ch] mt-4">
+            <p className="prose-copy mt-4">
               While we expose a web-based search interface, the real power of
               the Pandects platform lies in the <strong>API </strong>and
               associated <strong>MCP server</strong>. By creating a free
@@ -237,7 +326,7 @@ export default function About() {
               </h2>
             </div>
 
-            <p className="prose prose-copy max-w-[68ch] mt-6">
+            <p className="prose-copy mt-6">
               This is an open-source project, and contributions are welcome.
               See the{" "}
               <a
@@ -410,27 +499,6 @@ export default function About() {
             </dl>
           </section>
         </article>
-
-        <aside className="hidden lg:block">
-          <nav className="sticky top-24 text-xs">
-            {tocItems.map(({ id, label }) => {
-              const active = activeId === id;
-              return (
-                <a
-                  key={id}
-                  href={`#${id}`}
-                  className={
-                    active
-                      ? "block py-1 transition-colors text-primary font-medium border-l-2 border-primary pl-2 -ml-2"
-                      : "block py-1 text-muted-foreground hover:text-foreground transition-colors"
-                  }
-                >
-                  {label}
-                </a>
-              );
-            })}
-          </nav>
-        </aside>
       </div>
     </PageShell>
   );

--- a/frontend/client/pages/AgreementIndex.tsx
+++ b/frontend/client/pages/AgreementIndex.tsx
@@ -49,7 +49,7 @@ import {
 } from "@/components/ui/accordion";
 import { apiUrl } from "@/lib/api-config";
 import { authFetch } from "@/lib/auth-fetch";
-import { readSessionCache, writeSessionCache } from "@/lib/session-cache";
+import { useAgreementSummary } from "@/hooks/use-agreement-summary";
 import { cn } from "@/lib/utils";
 import { scheduleWhenBrowserIdle } from "@/lib/analytics";
 import { Link } from "react-router-dom";
@@ -81,12 +81,6 @@ type AgreementIndexResponse = {
   total_pages: number;
   has_next: boolean;
   has_prev: boolean;
-};
-
-type AgreementIndexSummary = {
-  agreements: number;
-  sections: number;
-  pages: number;
 };
 
 type SortColumn = "year" | "target" | "acquirer";
@@ -123,20 +117,14 @@ const summaryCards = [
     description: "Pages parsed across filings",
   },
 ] as const;
-const AGREEMENT_SUMMARY_CACHE_KEY = "agreement-index-summary:v1";
-const AGREEMENT_SUMMARY_CACHE_TTL_MS = 5 * 60 * 1000;
-
 export default function AgreementIndex() {
   const docsUrl = import.meta.env.DEV ? "http://localhost:3001" : brandLinks.docsSiteUrl;
   const [isPending, startPageTransition] = useTransition();
-  const [summary, setSummary] = useState<AgreementIndexSummary | null>(() =>
-    readSessionCache<AgreementIndexSummary>(
-      AGREEMENT_SUMMARY_CACHE_KEY,
-      AGREEMENT_SUMMARY_CACHE_TTL_MS,
-    ),
-  );
-  const [summaryLoading, setSummaryLoading] = useState(summary === null);
-  const [summaryError, setSummaryError] = useState<string | null>(null);
+  const {
+    summary,
+    isLoading: summaryLoading,
+    error: summaryError,
+  } = useAgreementSummary();
   const [hasLoadedOverview, setHasLoadedOverview] = useState(false);
   const [showSupplementaryPanels, setShowSupplementaryPanels] = useState(false);
 
@@ -151,63 +139,6 @@ export default function AgreementIndex() {
   const [sort_dir, setSortDir] = useState<SortDirection>("desc");
   const [filterInput, setFilterInput] = useState("");
   const [filterQuery, setFilterQuery] = useState("");
-  useEffect(() => {
-    let cancelled = false;
-    let timeoutId: number | null = null;
-    let idleId: number | null = null;
-
-    const fetchSummary = async () => {
-      try {
-        setSummaryLoading(true);
-        setSummaryError(null);
-        const res = await authFetch(apiUrl("v1/agreements-summary"));
-        if (!res.ok) {
-          throw new Error(`Summary request failed (${res.status})`);
-        }
-        const data = (await res.json()) as AgreementIndexSummary;
-        if (!cancelled) {
-          setSummary(data);
-          writeSessionCache(AGREEMENT_SUMMARY_CACHE_KEY, data);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setSummaryError(
-            err instanceof Error
-              ? err.message
-              : "Unable to load agreement summary.",
-          );
-        }
-      } finally {
-        if (!cancelled) {
-          setSummaryLoading(false);
-        }
-      }
-    };
-
-    const scheduleFetch = () => {
-      if (cancelled) return;
-      void fetchSummary();
-    };
-
-    const browserWindow = typeof window !== "undefined" ? window : null;
-
-    if (browserWindow && "requestIdleCallback" in browserWindow) {
-      idleId = browserWindow.requestIdleCallback(scheduleFetch, { timeout: 1500 });
-    } else {
-      timeoutId = window.setTimeout(scheduleFetch, 800);
-    }
-
-    return () => {
-      cancelled = true;
-      if (idleId !== null && browserWindow && "cancelIdleCallback" in browserWindow) {
-        browserWindow.cancelIdleCallback(idleId);
-      }
-      if (timeoutId !== null) {
-        window.clearTimeout(timeoutId);
-      }
-    };
-  }, []);
-
   useEffect(() => {
     let cancelled = false;
     const controller = new AbortController();


### PR DESCRIPTION
## Summary
- Project hero band (eyebrow + lede + primary rule) at the top
- Chip + h2 section-header pattern (01/02/03) replacing full-width top borders
- 4-card quick-facts strip above Overview (cadence, format, access, source)
- Two card grids for Contributing ("Where help is most welcome" + "On the roadmap")
- Credits converted to a definition list grouped by role
- Sticky right-rail TOC at lg+ with IntersectionObserver-driven active state
- External-link ↗ icon added to every target=_blank anchor

All existing anchor IDs, URLs, and aria-labels preserved. No theme tokens or dependencies added.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [ ] Visual review in dev