### PR TITLE
Enforce OAuth client grant-type registration

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1498,6 +1498,17 @@ def register_auth_routes(app: Flask, *, deps: AuthDeps) -> Blueprint:
                 return True
         return False
 
+    def _oauth_client_supports_grant_type(client, grant_type: str) -> bool:
+        raw_grant_types = getattr(client, "grant_types", None)
+        if not isinstance(raw_grant_types, list):
+            return False
+        normalized = {
+            str(item).strip()
+            for item in raw_grant_types
+            if isinstance(item, str) and item.strip()
+        }
+        return grant_type in normalized
+
     def _valid_oauth_redirect_uri(redirect_uri: str) -> bool:
         if "\\" in redirect_uri:
             return False
@@ -1823,22 +1834,25 @@ window.location.replace({json.dumps(login_url)});
                 token_id=str(uuid.uuid4()),
             ),
         )
-        raw_refresh = secrets.token_urlsafe(32)
-        refresh_record = deps.AuthOAuthRefreshToken(
-            token_hash=_oauth_code_hash(raw_refresh),
-            client_id=client_id,
-            user_id=user_id,
-            scope=scope,
-            expires_at=deps._utc_now() + timedelta(seconds=mcp_oauth_refresh_token_ttl_seconds()),
-        )
-        deps.db.session.add(refresh_record)
-        return {
+        token_payload: dict[str, object] = {
             "access_token": access_token,
             "token_type": "Bearer",
             "expires_in": mcp_oauth_access_token_ttl_seconds(),
             "scope": scope,
-            "refresh_token": raw_refresh,
         }
+        client = deps.AuthOAuthClient.query.filter_by(client_id=client_id).first()
+        if client is not None and _oauth_client_supports_grant_type(client, "refresh_token"):
+            raw_refresh = secrets.token_urlsafe(32)
+            refresh_record = deps.AuthOAuthRefreshToken(
+                token_hash=_oauth_code_hash(raw_refresh),
+                client_id=client_id,
+                user_id=user_id,
+                scope=scope,
+                expires_at=deps._utc_now() + timedelta(seconds=mcp_oauth_refresh_token_ttl_seconds()),
+            )
+            deps.db.session.add(refresh_record)
+            token_payload["refresh_token"] = raw_refresh
+        return token_payload
 
     @auth_blp.post("/oauth/token")
     def oauth_token():
@@ -1855,6 +1869,8 @@ window.location.replace({json.dumps(login_url)});
             client = deps.AuthOAuthClient.query.filter_by(client_id=client_id).first()
             if client is None or not _oauth_redirect_uri_allowed(client, redirect_uri):
                 abort(400, description="Invalid OAuth client or redirect URI.")
+            if not _oauth_client_supports_grant_type(client, "authorization_code"):
+                abort(400, description="OAuth client does not support the authorization_code grant.")
             auth_code = deps.AuthOAuthAuthorizationCode.query.filter_by(
                 code_hash=_oauth_code_hash(code),
                 client_id=client.client_id,
@@ -1887,6 +1903,8 @@ window.location.replace({json.dumps(login_url)});
             client = deps.AuthOAuthClient.query.filter_by(client_id=client_id).first()
             if client is None:
                 abort(400, description="Invalid OAuth client.")
+            if not _oauth_client_supports_grant_type(client, "refresh_token"):
+                abort(400, description="OAuth client does not support the refresh_token grant.")
             refresh_record = deps.AuthOAuthRefreshToken.query.filter_by(
                 token_hash=_oauth_code_hash(raw_refresh),
                 client_id=client.client_id,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -44,7 +44,7 @@ os.environ["AUTH_DATABASE_URI"] = f"sqlite:///{_AUTH_DB_TEMP.name}"
 
 from backend.app import create_test_app  # noqa: E402
 from backend.extensions import db  # noqa: E402
-from backend.models.auth import ApiKey, ApiUsageDaily, AuthExternalSubject, AuthUser, LegalAcceptance  # noqa: E402
+from backend.models.auth import ApiKey, ApiUsageDaily, AuthExternalSubject, AuthOAuthRefreshToken, AuthUser, LegalAcceptance  # noqa: E402
 import backend.app as backend_app  # noqa: E402
 import backend.routes.auth as auth_routes  # noqa: E402
 from werkzeug.exceptions import Conflict, NotFound, Unauthorized  # noqa: E402
@@ -2737,7 +2737,9 @@ class AuthFlowTests(unittest.TestCase):
             },
         )
         self.assertEqual(token.status_code, 200)
-        access_token = token.get_json()["access_token"]
+        token_json = token.get_json()
+        self.assertNotIn("refresh_token", token_json)
+        access_token = token_json["access_token"]
 
         mcp = client.post(
             "/mcp",
@@ -2901,6 +2903,55 @@ class AuthFlowTests(unittest.TestCase):
         )
         self.assertEqual(second_refresh.status_code, 200)
         self.assertIn("access_token", second_refresh.get_json())
+
+    def test_refresh_token_grant_rejects_client_without_refresh_token_registration(self):
+        os.environ["AUTH_SESSION_TRANSPORT"] = "cookie"
+        client = self.app.test_client()
+        user_id = self._create_local_user(email="refresh-disallowed@example.com")
+        with self.app.app_context():
+            db.session.add(
+                self._auth_external_subject(
+                    user_id=user_id,
+                    issuer="https://pandects-test-zitadel.example.com",
+                    subject="refresh-disallowed-zitadel-user",
+                )
+            )
+            db.session.commit()
+        self._set_cookie_session(client, email="refresh-disallowed@example.com")
+
+        register = client.post(
+            "/v1/auth/oauth/register",
+            json={
+                "client_name": "Codex MCP",
+                "redirect_uris": ["https://codex.example.com/callback"],
+                "grant_types": ["authorization_code"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "none",
+            },
+        )
+        self.assertEqual(register.status_code, 201)
+        client_id = register.get_json()["client_id"]
+
+        with self.app.app_context():
+            refresh = AuthOAuthRefreshToken()
+            refresh.client_id = client_id
+            refresh.user_id = user_id
+            refresh.scope = "agreements:read"
+            refresh.expires_at = backend_app._utc_now() + timedelta(hours=1)
+            raw_refresh = "seeded-refresh-token"
+            refresh.token_hash = hashlib.sha256(raw_refresh.encode("utf-8")).hexdigest()
+            db.session.add(refresh)
+            db.session.commit()
+
+        refreshed = client.post(
+            "/v1/auth/oauth/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": client_id,
+                "refresh_token": raw_refresh,
+            },
+        )
+        self.assertEqual(refreshed.status_code, 400)
 
     def test_oauth_authorize_returns_login_bridge_when_session_transport_is_bearer(self):
         os.environ["AUTH_SESSION_TRANSPORT"] = "bearer"


### PR DESCRIPTION
## Summary

Tightens the \`/oauth/token\` endpoint so registered grant types are actually enforced. Before this change, any registered OAuth client could redeem an \`authorization_code\` or a \`refresh_token\` grant regardless of which grants the client was actually registered for, and a refresh token was minted alongside every access token unconditionally.

After this change:

1. **\`authorization_code\` requests** are rejected with HTTP 400 when the client's stored \`grant_types\` list does not include that grant.
2. **\`refresh_token\` requests** are rejected the same way.
3. **Refresh tokens are only minted** alongside the access token when the client is registered for the \`refresh_token\` grant. Clients without that registration (e.g. short-lived public clients) get an access-token-only response.

A small helper \`_oauth_client_supports_grant_type\` normalizes the stored list (string elements, trimmed, deduplicated via set) before checking membership, and tolerates malformed/missing data by returning \`False\`.

## Test plan

- [x] \`backend.tests.test_auth\` — 65 tests passing, including two new cases covering the access-only response and the rejection path
- [ ] Manual smoke against a registered client to confirm:
  - Authorization-code-only client redeems access token without a refresh token
  - Refresh-token-registered client still gets both tokens
  - Mismatched grant request returns 400 with the new message