### PR TITLE
Landing page: live stats + featured agreements rail

### DIFF
--- a/frontend/client/components/FeaturedAgreements.tsx
+++ b/frontend/client/components/FeaturedAgreements.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { ArrowRight } from "lucide-react";
+import { useRecentAgreements } from "@/hooks/use-recent-agreements";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trackEvent } from "@/lib/analytics";
+import { cn } from "@/lib/utils";
+
+interface FeaturedAgreementsProps {
+  limit?: number;
+  className?: string;
+}
+
+const FILING_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "short",
+});
+
+function formatFilingDate(value: string | null): string | null {
+  if (!value) return null;
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return null;
+  return FILING_DATE_FORMATTER.format(dt);
+}
+
+/**
+ * Compact rail of the most-recently-filed agreements, each clickable through
+ * to its detail page. Rendered on the landing page so first-time visitors see
+ * real, current data — not just a marketing card.
+ *
+ * SSR-safe: returns an empty placeholder during prerender (useRecentAgreements
+ * is gated on IS_SERVER_RENDER) and a skeleton while loading on hydration. If
+ * the fetch fails we render nothing rather than an error UI; the landing page
+ * still works without this section.
+ */
+export function FeaturedAgreements({
+  limit = 4,
+  className,
+}: FeaturedAgreementsProps) {
+  // Defer rendering until after hydration. Prerender returns null (the query
+  // is gated on IS_SERVER_RENDER), so anything we render on the very first
+  // client paint would diverge from the SSR DOM and trigger a hydration
+  // mismatch warning. One-shot effect flips us into the live state.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+
+  const { results, isLoading, error } = useRecentAgreements(limit);
+
+  if (!hydrated) return null;
+  if (error || (!isLoading && results.length === 0)) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-labelledby="featured-agreements-heading"
+      className={cn("w-full", className)}
+    >
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <h2
+          id="featured-agreements-heading"
+          className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground"
+        >
+          Latest agreements
+        </h2>
+        <Link
+          to="/agreement-index"
+          className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          onClick={() =>
+            trackEvent("landing_featured_agreements_view_all", {
+              to_path: "/agreement-index",
+            })
+          }
+        >
+          View all →
+        </Link>
+      </div>
+
+      <ul
+        className="grid gap-2 sm:grid-cols-2"
+        aria-busy={isLoading || undefined}
+      >
+        {isLoading
+          ? Array.from({ length: limit }).map((_, index) => (
+              <li key={`skeleton-${index}`}>
+                <FeaturedAgreementSkeleton />
+              </li>
+            ))
+          : results.map((result, position) => (
+              <li key={result.agreement_uuid}>
+                <FeaturedAgreementCard result={result} position={position} />
+              </li>
+            ))}
+      </ul>
+    </section>
+  );
+}
+
+function FeaturedAgreementSkeleton() {
+  return (
+    <div className="rounded-lg border border-border bg-background/60 p-3">
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="mt-2 h-3 w-2/3" />
+      <Skeleton className="mt-3 h-3 w-24" />
+    </div>
+  );
+}
+
+function FeaturedAgreementCard({
+  result,
+  position,
+}: {
+  result: NonNullable<ReturnType<typeof useRecentAgreements>["results"]>[number];
+  position: number;
+}) {
+  const filed = formatFilingDate(result.filing_date);
+  const target = result.target?.trim() || "Unknown target";
+  const acquirer = result.acquirer?.trim() || "Unknown acquirer";
+
+  return (
+    <Link
+      to={`/agreements/${result.agreement_uuid}`}
+      onClick={() =>
+        trackEvent("landing_featured_agreement_click", {
+          position,
+          year: result.year ?? undefined,
+          agreement_uuid: result.agreement_uuid,
+        })
+      }
+      className="group block h-full rounded-lg border border-border bg-background/70 p-3 text-left transition-colors hover:border-border hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-foreground">
+            {target}
+          </p>
+          <p className="truncate text-xs text-muted-foreground">
+            acquired by {acquirer}
+          </p>
+        </div>
+        <ArrowRight
+          className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground/60 transition-colors group-hover:text-foreground"
+          aria-hidden="true"
+        />
+      </div>
+      {filed ? (
+        <p className="mt-2 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
+          Filed {filed}
+        </p>
+      ) : null}
+    </Link>
+  );
+}

--- a/frontend/client/components/FeaturedAgreements.tsx
+++ b/frontend/client/components/FeaturedAgreements.tsx
@@ -65,7 +65,7 @@ export function FeaturedAgreements({
         </h2>
         <Link
           to="/agreement-index"
-          className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          className="-mx-2 inline-flex min-h-11 items-center rounded-md px-2 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:mx-0 sm:min-h-0 sm:px-0"
           onClick={() =>
             trackEvent("landing_featured_agreements_view_all", {
               to_path: "/agreement-index",

--- a/frontend/client/hooks/use-recent-agreements.ts
+++ b/frontend/client/hooks/use-recent-agreements.ts
@@ -1,0 +1,49 @@
+import { useQuery } from "@tanstack/react-query";
+import type { TransactionSearchResponse } from "@shared/transactions";
+import { apiUrl } from "@/lib/api-config";
+import { authFetch } from "@/lib/auth-fetch";
+import { IS_SERVER_RENDER } from "@/lib/query-client";
+
+/**
+ * Fetches the N most-recently-filed agreements. Used on the landing page to
+ * show real, clickable previews of what's in the dataset.
+ *
+ * Reuses the agreement-search endpoint with no filters; sort_by=year is keyed
+ * to filing_date server-side, so this returns the freshest entries.
+ */
+async function fetchRecentAgreements(
+  limit: number,
+): Promise<TransactionSearchResponse> {
+  const params = new URLSearchParams();
+  params.set("sort_by", "year");
+  params.set("sort_direction", "desc");
+  params.set("page", "1");
+  params.set("page_size", String(limit));
+  const res = await authFetch(
+    apiUrl(`v1/search/agreements?${params.toString()}`),
+  );
+  if (!res.ok) {
+    throw new Error(`Recent agreements request failed (${res.status})`);
+  }
+  return (await res.json()) as TransactionSearchResponse;
+}
+
+export function useRecentAgreements(limit: number = 4) {
+  const query = useQuery({
+    queryKey: ["recent-agreements", limit] as const,
+    queryFn: () => fetchRecentAgreements(limit),
+    enabled: !IS_SERVER_RENDER,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+
+  return {
+    results: query.data?.results ?? [],
+    isLoading: query.isLoading,
+    error: query.error
+      ? query.error instanceof Error
+        ? query.error.message
+        : "Failed to load recent agreements."
+      : null,
+  };
+}

--- a/frontend/client/pages/Landing.tsx
+++ b/frontend/client/pages/Landing.tsx
@@ -8,11 +8,35 @@ import { Link } from "react-router-dom";
 import { trackEvent } from "@/lib/analytics";
 import { Code, Database } from "lucide-react";
 import { Card } from "@/components/ui/card";
+import { FeaturedAgreements } from "@/components/FeaturedAgreements";
+import { useAgreementSummary } from "@/hooks/use-agreement-summary";
+import { formatNumber } from "@/lib/format-utils";
 import brandLinks from "@branding/links.json";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+const LATEST_FILING_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "short",
+});
+
+function formatLatestFiling(value: string | null): string | null {
+  if (!value) return null;
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return null;
+  return LATEST_FILING_FORMATTER.format(dt);
+}
 
 export default function Landing() {
   const docsUrl = import.meta.env.DEV ? "http://localhost:3001" : brandLinks.docsSiteUrl;
+  const { summary } = useAgreementSummary();
+  const liveStats = useMemo(() => {
+    if (!summary) return null;
+    const latestFiling = formatLatestFiling(summary.latest_filing_date);
+    return {
+      agreements: formatNumber(summary.agreements),
+      latestFiling,
+    };
+  }, [summary]);
   const headerBadgeRef = useRef<HTMLDivElement | null>(null);
   const sourcedTextRef = useRef<HTMLSpanElement | null>(null);
   const updatedTextRef = useRef<HTMLSpanElement | null>(null);
@@ -136,6 +160,26 @@ export default function Landing() {
               The fastest way to query deal data, open-source.
             </p>
 
+            {liveStats ? (
+              <p
+                className="mt-2 text-sm text-muted-foreground"
+                aria-live="polite"
+              >
+                <span className="font-medium text-foreground/80">
+                  {liveStats.agreements}
+                </span>{" "}
+                agreements indexed
+                {liveStats.latestFiling ? (
+                  <>
+                    <span aria-hidden="true" className="mx-2 text-foreground/40">
+                      ·
+                    </span>
+                    Latest filing {liveStats.latestFiling}
+                  </>
+                ) : null}
+              </p>
+            ) : null}
+
             <div className="mt-12 flex w-full flex-col items-center gap-3">
               <Button
                 asChild
@@ -155,7 +199,9 @@ export default function Landing() {
               </Button>
             </div>
 
-            <div className="mt-6 flex flex-col items-center gap-3 sm:mt-4">
+            <FeaturedAgreements className="mt-10" />
+
+            <div className="mt-8 flex flex-col items-center gap-3 sm:mt-6">
               <div className="flex flex-wrap items-center justify-center gap-3 text-sm sm:gap-4">
                 <Button
                   asChild

--- a/frontend/client/pages/Landing.tsx
+++ b/frontend/client/pages/Landing.tsx
@@ -206,7 +206,7 @@ export default function Landing() {
                 <Button
                   asChild
                   variant="link"
-                  className="h-auto gap-2 p-0 text-sm text-muted-foreground hover:text-foreground"
+                  className="min-h-11 gap-2 px-2 py-2 text-sm text-muted-foreground hover:text-foreground sm:min-h-0 sm:p-0"
                 >
                   <a
                     href={`${docsUrl}/docs/mcp/using`}
@@ -238,7 +238,7 @@ export default function Landing() {
                 <Button
                   asChild
                   variant="link"
-                  className="h-auto gap-2 p-0 text-sm text-muted-foreground hover:text-foreground"
+                  className="min-h-11 gap-2 px-2 py-2 text-sm text-muted-foreground hover:text-foreground sm:min-h-0 sm:p-0"
                 >
                   <a
                     href="https://github.com/PlatosTwin/pandects-app/tree/main/examples"
@@ -261,7 +261,7 @@ export default function Landing() {
               <Button
                 asChild
                 variant="link"
-                className="h-auto gap-2 p-0 text-sm text-muted-foreground hover:text-foreground"
+                className="min-h-11 gap-2 px-2 py-2 text-sm text-muted-foreground hover:text-foreground sm:min-h-0 sm:p-0"
               >
                 <Link
                   to="/sources-methods"


### PR DESCRIPTION
## Summary

Replaces PR #43, which GitHub auto-closed when its base branch (`frontend/react-query-and-routing`) was deleted on merge of #42. The landing branch has been rebased onto the new `main` (now contains #42's squashed commit); content is unchanged.

Surfaces real, current data on the home page so first-time visitors see the product (a structured M&A dataset) instead of a marketing card. Brand frame is unchanged — same logo, badge, headline, tagline, CTA, and footer links. The negative space inside the card now has live content.

Two additions, both inside the existing centered Card:

1. **Live stats line** below the tagline. Reads "**N** agreements indexed · Latest filing Mon YYYY" using the existing `useAgreementSummary` hook. Skips rendering until the summary resolves on hydration, so the prerendered HTML stays unchanged and there's no hydration mismatch — the line just slots in once data arrives.

2. **Featured agreements rail** between the CTA and the footer links. Up to 4 most-recently-filed agreements as compact cards (target, "acquired by" acquirer, "Filed Mon YYYY"), each clicking to `/agreements/{uuid}`. New small RQ hook (`use-recent-agreements`) uses the existing `v1/search/agreements` endpoint sorted by year desc. Both the hook and the component gate on hydration via a one-shot `useState`/`useEffect` to avoid SSR mismatch warnings.

A small follow-up commit bumps the four small text-button links (the new "View all →" + the three pre-existing footer links) to a 44px touch target on mobile, resetting to the original inline look on `sm+`. Pairs with the new rail; no desktop visual change.

## Test plan

- [x] `npm test` — 20 files, 79 tests passing
- [x] `npm run typecheck` — clean
- [x] `npm run build` — client + prerender + SEO validators + asset budgets + server bundle, all green
- [x] Prerendered `/index.html` confirmed to contain none of the live-data widgets (no hydration mismatch)
- [ ] Manual smoke: load `/`, confirm stats line and rail populate after a tick, click into a featured agreement, resize to mobile to verify tap targets