### PR TITLE
Refetch on every Search commit (fix #51)

### DIFF
--- a/frontend/client/hooks/use-sections.ts
+++ b/frontend/client/hooks/use-sections.ts
@@ -22,6 +22,11 @@ interface CommittedQuery {
   clauseTypesNested?: ClauseTypeTree;
   sortBy: SortField | null;
   sortDirection: "asc" | "desc";
+  // Bumped on every commit so the queryKey is distinct even when filters/sort
+  // are unchanged from the previous attempt. Without this, a Search re-click
+  // after a failed fetch wouldn't refetch — React Query would just return the
+  // cached error for the same key.
+  nonce: number;
 }
 
 const EMPTY_FILTERS: SearchFilters = {
@@ -116,6 +121,7 @@ export function useSections() {
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const fireResultsLoadedRef = useRef(false);
+  const nonceRef = useRef(0);
 
   const committedQueryString = useMemo(
     () => (committed ? buildSectionsQueryString(committed) : ""),
@@ -123,7 +129,10 @@ export function useSections() {
   );
 
   const query = useQuery<SearchResponse>({
-    queryKey: keys.sections.search({ q: committedQueryString }),
+    queryKey: keys.sections.search({
+      q: committedQueryString,
+      n: committed?.nonce ?? 0,
+    }),
     enabled: !IS_SERVER_RENDER && committed !== null,
     staleTime: 60 * 1000,
     retry: (failureCount, error) =>
@@ -295,11 +304,13 @@ export function useSections() {
         });
       }
 
+      nonceRef.current += 1;
       setCommitted({
         filters: effective,
         clauseTypesNested,
         sortBy,
         sortDirection: sortDir,
+        nonce: nonceRef.current,
       });
     },
     [filters, currentSort, sort_direction],

--- a/frontend/client/hooks/use-tax-clauses.ts
+++ b/frontend/client/hooks/use-tax-clauses.ts
@@ -28,6 +28,11 @@ interface CommittedQuery {
   filters: TaxClauseFilters;
   sortBy: SortField | null;
   sortDirection: "asc" | "desc";
+  // Bumped on every commit so the queryKey is distinct even when filters/sort
+  // are unchanged from the previous attempt. Without this, a Search re-click
+  // after a failed fetch wouldn't refetch — React Query would just return the
+  // cached error for the same key.
+  nonce: number;
 }
 
 const EMPTY_FILTERS: TaxClauseFilters = {
@@ -111,6 +116,7 @@ export function useTaxClauses() {
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const fireResultsLoadedRef = useRef(false);
+  const nonceRef = useRef(0);
 
   const committedQueryString = useMemo(
     () => (committed ? buildCommittedQueryString(committed) : ""),
@@ -118,7 +124,10 @@ export function useTaxClauses() {
   );
 
   const query = useQuery<TaxClauseSearchResponse>({
-    queryKey: keys.taxClauses.search({ q: committedQueryString }),
+    queryKey: keys.taxClauses.search({
+      q: committedQueryString,
+      n: committed?.nonce ?? 0,
+    }),
     enabled: !IS_SERVER_RENDER && committed !== null,
     staleTime: 60 * 1000,
     retry: (failureCount, error) =>
@@ -268,7 +277,13 @@ export function useTaxClauses() {
         });
       }
 
-      setCommitted({ filters: effective, sortBy, sortDirection: sortDir });
+      nonceRef.current += 1;
+      setCommitted({
+        filters: effective,
+        sortBy,
+        sortDirection: sortDir,
+        nonce: nonceRef.current,
+      });
     },
     [filters, currentSort, sort_direction],
   );

--- a/frontend/client/hooks/use-transaction-search.ts
+++ b/frontend/client/hooks/use-transaction-search.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiUrl } from "@/lib/api-config";
 import { authFetch } from "@/lib/auth-fetch";
@@ -24,6 +24,11 @@ interface CommittedQuery {
   clauseTypesNested?: ClauseTypeTree;
   sortBy: "year" | "target" | "acquirer" | null;
   sortDirection: "asc" | "desc";
+  // Bumped on every commit so the queryKey is distinct even when filters/sort
+  // are unchanged from the previous attempt. Without this, a Search re-click
+  // after a failed fetch wouldn't refetch — React Query would just return the
+  // cached error for the same key.
+  nonce: number;
 }
 
 const EMPTY_ACCESS: TransactionSearchResponse["access"] = { tier: "anonymous" };
@@ -50,6 +55,7 @@ export function useTransactionSearch() {
   const [selectedResults, setSelectedResults] = useState<Set<string>>(new Set());
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const nonceRef = useRef(0);
 
   const committedQueryString = useMemo(
     () => (committed ? buildTransactionQueryString(committed) : ""),
@@ -57,7 +63,10 @@ export function useTransactionSearch() {
   );
 
   const query = useQuery<TransactionSearchResponse>({
-    queryKey: keys.transactions.search({ q: committedQueryString }),
+    queryKey: keys.transactions.search({
+      q: committedQueryString,
+      n: committed?.nonce ?? 0,
+    }),
     enabled: !IS_SERVER_RENDER && committed !== null,
     staleTime: 60 * 1000,
     queryFn: async () => {
@@ -114,7 +123,14 @@ export function useTransactionSearch() {
     }) => {
       setShowErrorModal(false);
       if (markAsSearched) setHasSearched(true);
-      setCommitted({ filters, clauseTypesNested, sortBy, sortDirection });
+      nonceRef.current += 1;
+      setCommitted({
+        filters,
+        clauseTypesNested,
+        sortBy,
+        sortDirection,
+        nonce: nonceRef.current,
+      });
     },
     [],
   );


### PR DESCRIPTION
## Summary
Fixes #51 — failed search → re-click Search with same filters → nothing happens.

## Root cause
`setCommitted({...same params})` produced a new object reference but the same serialized query string, so the `useQuery` key was unchanged. RQ returned the cached error state without refetching, and `query.error` was the same `Error` reference so the error effect didn't refire.

## Fix
Add a monotonic `nonce` (incremented via `useRef`) to each `CommittedQuery`, included in the queryKey object but **not** in the URL or query string. Every commit produces a distinct key, so RQ refetches even when filters and sort are identical to the previous attempt.

```ts
const nonceRef = useRef(0);
// ...
nonceRef.current += 1;
setCommitted({ ...params, nonce: nonceRef.current });
```

```ts
queryKey: keys.X.search({ q: committedQueryString, n: committed?.nonce ?? 0 })
```

## Tradeoff
Loses dedup on back-to-back same-param Search clicks within `staleTime` (60s). Negligible — and the imperative `queryClient.fetchQuery` it replaced also refetched on every call after an error, so this restores parity with that behavior.

## Scope
All three search hooks:
- `client/hooks/use-tax-clauses.ts`
- `client/hooks/use-transaction-search.ts`
- `client/hooks/use-sections.ts`

Net diff: +48 / −6.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — all 79 tests pass
- [x] `npm run build` succeeds
- [ ] Manual: stop backend → search → see error modal → restart backend → dismiss modal → click Search with same filters → should refetch successfully

Closes #51