### PR TITLE
Extract favorites helpers into submodule

### DIFF
--- a/backend/routes/favorites/__init__.py
+++ b/backend/routes/favorites/__init__.py
@@ -9,16 +9,28 @@ state, not part of the public API.
 from __future__ import annotations
 
 import uuid
-from collections.abc import Callable
-from dataclasses import dataclass
-from datetime import datetime
 from typing import Any, cast
 
 from flask import Blueprint, Flask, abort, jsonify, make_response, request
-from marshmallow import Schema
 from sqlalchemy.exc import SQLAlchemyError
 
-from backend.routes.deps import AccessContextProtocol, UserLikeProtocol
+from backend.routes.deps import UserLikeProtocol
+from backend.routes.favorites.deps import FavoritesDeps
+from backend.routes.favorites.helpers import (
+    _backfill_favorite_project_assignments,
+    _db_session,
+    _ensure_default_project,
+    _ensure_favorite_project_assignment,
+    _load_projects_for_favorites,
+    _load_tags_for_favorites,
+    _next_project_sort_order,
+    _no_store,
+    _resolve_agreement_uuids,
+    _serialize_favorite,
+    _serialize_favorite_minimal,
+    _serialize_project,
+    _serialize_tag,
+)
 from backend.schemas.favorites import (
     ITEM_TYPES,
     TAG_COLORS,
@@ -37,232 +49,7 @@ from backend.schemas.favorites import (
     TagUpdateSchema,
 )
 
-
-@dataclass(frozen=True)
-class FavoritesDeps:
-    Favorite: type
-    FavoriteProject: type
-    FavoriteProjectAssignment: type
-    FavoriteTag: type
-    FavoriteTagAssignment: type
-    Sections: type
-    Clauses: type
-    Agreements: type
-    db: object
-    _require_auth_db: Callable[[], None]
-    _require_verified_user: Callable[[], tuple[UserLikeProtocol, AccessContextProtocol]]
-    _auth_is_mocked: Callable[[], bool]
-    _load_json: Callable[[Schema], dict[str, object]]
-    _utc_now: Callable[[], datetime]
-
-
-_DEFAULT_PROJECT_NAME = "Scratchpad"
-
-
-def _db_session(deps: FavoritesDeps) -> Any:
-    return cast(Any, deps.db).session
-
-
-def _ensure_default_project(deps: FavoritesDeps, *, user_id: str):
-    project = deps.FavoriteProject.query.filter_by(
-        user_id=user_id, is_default=True
-    ).first()
-    if project is not None:
-        return project
-    project = deps.FavoriteProject()  # type: ignore[call-arg]
-    project.id = str(uuid.uuid4())
-    project.user_id = user_id
-    project.name = _DEFAULT_PROJECT_NAME
-    project.color = "slate"
-    project.is_default = True
-    project.sort_order = 0
-    _db_session(deps).add(project)
-    _db_session(deps).commit()
-    return project
-
-
-def _serialize_favorite(
-    fav,
-    *,
-    agreement_uuid: str | None,
-    tags: list[dict[str, object]] | None = None,
-    project_ids: list[str] | None = None,
-) -> dict[str, object]:
-    return {
-        "id": fav.id,
-        "project_id": fav.project_id,
-        "project_ids": project_ids or [fav.project_id],
-        "item_type": fav.item_type,
-        "item_uuid": fav.item_uuid,
-        "agreement_uuid": agreement_uuid,
-        "note": fav.note,
-        "context": fav.context,
-        "tags": tags or [],
-        "created_at": fav.created_at.isoformat() if fav.created_at else None,
-        "updated_at": fav.updated_at.isoformat() if fav.updated_at else None,
-    }
-
-
-def _serialize_favorite_minimal(fav) -> dict[str, object]:
-    return {
-        "id": fav.id,
-        "project_id": fav.project_id,
-        "project_ids": [fav.project_id],
-        "item_type": fav.item_type,
-        "item_uuid": fav.item_uuid,
-        "note": fav.note,
-        "context": fav.context,
-        "created_at": fav.created_at.isoformat() if fav.created_at else None,
-        "updated_at": fav.updated_at.isoformat() if fav.updated_at else None,
-    }
-
-
-def _serialize_project(project) -> dict[str, object]:
-    return {
-        "id": project.id,
-        "name": project.name,
-        "color": project.color,
-        "is_default": bool(project.is_default),
-        "sort_order": project.sort_order,
-        "created_at": project.created_at.isoformat() if project.created_at else None,
-    }
-
-
-def _serialize_tag(tag) -> dict[str, object]:
-    return {
-        "id": tag.id,
-        "name": tag.name,
-        "color": tag.color,
-        "created_at": tag.created_at.isoformat() if tag.created_at else None,
-    }
-
-
-def _next_project_sort_order(deps: FavoritesDeps, *, user_id: str) -> int:
-    rows = deps.FavoriteProject.query.filter_by(user_id=user_id).all()
-    if not rows:
-        return 0
-    return max(int(row.sort_order or 0) for row in rows) + 1
-
-
-def _load_tags_for_favorites(
-    deps: FavoritesDeps, *, favorite_ids: list[str]
-) -> dict[str, list[dict[str, object]]]:
-    if not favorite_ids:
-        return {}
-    db_obj = cast(Any, deps.db)
-    session = db_obj.session
-    rows = (
-        session.query(
-            deps.FavoriteTagAssignment.favorite_id,
-            deps.FavoriteTag.id,
-            deps.FavoriteTag.name,
-            deps.FavoriteTag.color,
-        )
-        .join(
-            deps.FavoriteTag,
-            deps.FavoriteTag.id == deps.FavoriteTagAssignment.tag_id,
-        )
-        .filter(
-            deps.FavoriteTagAssignment.favorite_id.in_(favorite_ids)
-        )
-        .order_by(deps.FavoriteTag.name.asc())
-        .all()
-    )
-    out: dict[str, list[dict[str, object]]] = {}
-    for favorite_id, tag_id, name, color in rows:
-        out.setdefault(favorite_id, []).append(
-            {"id": tag_id, "name": name, "color": color}
-        )
-    return out
-
-
-def _load_projects_for_favorites(
-    deps: FavoritesDeps, *, favorite_ids: list[str]
-) -> dict[str, list[str]]:
-    if not favorite_ids:
-        return {}
-    rows = (
-        _db_session(deps)
-        .query(
-            deps.FavoriteProjectAssignment.favorite_id,
-            deps.FavoriteProjectAssignment.project_id,
-        )
-        .filter(deps.FavoriteProjectAssignment.favorite_id.in_(favorite_ids))
-        .all()
-    )
-    out: dict[str, list[str]] = {}
-    for favorite_id, project_id in rows:
-        out.setdefault(favorite_id, []).append(project_id)
-    return out
-
-
-def _ensure_favorite_project_assignment(
-    deps: FavoritesDeps, *, favorite_id: str, project_id: str
-) -> None:
-    existing = deps.FavoriteProjectAssignment.query.filter_by(
-        favorite_id=favorite_id, project_id=project_id
-    ).first()
-    if existing is not None:
-        return
-    assignment = deps.FavoriteProjectAssignment()  # type: ignore[call-arg]
-    assignment.favorite_id = favorite_id
-    assignment.project_id = project_id
-    _db_session(deps).add(assignment)
-
-
-def _backfill_favorite_project_assignments(deps: FavoritesDeps, *, user_id: str) -> None:
-    favorites = deps.Favorite.query.filter_by(user_id=user_id).all()
-    for fav in favorites:
-        _ensure_favorite_project_assignment(
-            deps, favorite_id=fav.id, project_id=fav.project_id
-        )
-
-
-def _resolve_agreement_uuids(
-    deps: FavoritesDeps, *, favorites: list[object]
-) -> dict[tuple[str, str], str]:
-    section_uuids: list[str] = []
-    clause_uuids: list[str] = []
-    agreement_uuids: list[str] = []
-    for fav in favorites:
-        item_type = cast(str, getattr(fav, "item_type"))
-        item_uuid = cast(str, getattr(fav, "item_uuid"))
-        if item_type == "section":
-            section_uuids.append(item_uuid)
-        elif item_type == "tax_clause":
-            clause_uuids.append(item_uuid)
-        elif item_type == "agreement":
-            agreement_uuids.append(item_uuid)
-
-    resolved: dict[tuple[str, str], str] = {}
-    db_obj = cast(Any, deps.db)
-    session = db_obj.session
-
-    if section_uuids:
-        rows = (
-            session.query(deps.Sections.section_uuid, deps.Sections.agreement_uuid)
-            .filter(deps.Sections.section_uuid.in_(section_uuids))
-            .all()
-        )
-        for section_uuid, agreement_uuid in rows:
-            resolved[("section", section_uuid)] = agreement_uuid
-    if clause_uuids:
-        rows = (
-            session.query(deps.Clauses.clause_uuid, deps.Clauses.agreement_uuid)
-            .filter(deps.Clauses.clause_uuid.in_(clause_uuids))
-            .all()
-        )
-        for clause_uuid, agreement_uuid in rows:
-            resolved[("tax_clause", clause_uuid)] = agreement_uuid
-    for agreement_uuid in agreement_uuids:
-        resolved[("agreement", agreement_uuid)] = agreement_uuid
-    return resolved
-
-
-def _no_store(payload: object):
-    resp = make_response(jsonify(payload))
-    resp.headers["Cache-Control"] = "no-store"
-    return resp
+__all__ = ["FavoritesDeps", "register_favorites_routes"]
 
 
 def register_favorites_routes(target_app: Flask, *, deps: FavoritesDeps) -> Blueprint:

--- a/backend/routes/favorites/__init__.py
+++ b/backend/routes/favorites/__init__.py
@@ -9,9 +9,9 @@ state, not part of the public API.
 from __future__ import annotations
 
 import uuid
-from typing import Any, cast
+from typing import cast
 
-from flask import Blueprint, Flask, abort, jsonify, make_response, request
+from flask import Blueprint, Flask, abort, request
 from sqlalchemy.exc import SQLAlchemyError
 
 from backend.routes.deps import UserLikeProtocol

--- a/backend/routes/favorites/deps.py
+++ b/backend/routes/favorites/deps.py
@@ -1,0 +1,33 @@
+"""Dependency container for the favorites blueprint.
+
+Split from ``__init__`` so helper submodules can import the type without
+circularity.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+
+from marshmallow import Schema
+
+from backend.routes.deps import AccessContextProtocol, UserLikeProtocol
+
+
+@dataclass(frozen=True)
+class FavoritesDeps:
+    Favorite: type
+    FavoriteProject: type
+    FavoriteProjectAssignment: type
+    FavoriteTag: type
+    FavoriteTagAssignment: type
+    Sections: type
+    Clauses: type
+    Agreements: type
+    db: object
+    _require_auth_db: Callable[[], None]
+    _require_verified_user: Callable[[], tuple[UserLikeProtocol, AccessContextProtocol]]
+    _auth_is_mocked: Callable[[], bool]
+    _load_json: Callable[[Schema], dict[str, object]]
+    _utc_now: Callable[[], datetime]

--- a/backend/routes/favorites/helpers.py
+++ b/backend/routes/favorites/helpers.py
@@ -1,0 +1,224 @@
+"""Module-level helpers for the favorites blueprint.
+
+Serializers, project/tag loaders, and small DB utilities. Each helper takes
+the explicit ``FavoritesDeps`` instance rather than capturing it from a
+closure, so they live cleanly outside ``register_favorites_routes``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+
+from flask import jsonify, make_response
+
+from backend.routes.favorites.deps import FavoritesDeps
+
+
+_DEFAULT_PROJECT_NAME = "Scratchpad"
+
+
+def _db_session(deps: FavoritesDeps) -> Any:
+    return cast(Any, deps.db).session
+
+
+def _ensure_default_project(deps: FavoritesDeps, *, user_id: str):
+    project = deps.FavoriteProject.query.filter_by(
+        user_id=user_id, is_default=True
+    ).first()
+    if project is not None:
+        return project
+    project = deps.FavoriteProject()  # type: ignore[call-arg]
+    project.id = str(uuid.uuid4())
+    project.user_id = user_id
+    project.name = _DEFAULT_PROJECT_NAME
+    project.color = "slate"
+    project.is_default = True
+    project.sort_order = 0
+    _db_session(deps).add(project)
+    _db_session(deps).commit()
+    return project
+
+
+def _serialize_favorite(
+    fav,
+    *,
+    agreement_uuid: str | None,
+    tags: list[dict[str, object]] | None = None,
+    project_ids: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "id": fav.id,
+        "project_id": fav.project_id,
+        "project_ids": project_ids or [fav.project_id],
+        "item_type": fav.item_type,
+        "item_uuid": fav.item_uuid,
+        "agreement_uuid": agreement_uuid,
+        "note": fav.note,
+        "context": fav.context,
+        "tags": tags or [],
+        "created_at": fav.created_at.isoformat() if fav.created_at else None,
+        "updated_at": fav.updated_at.isoformat() if fav.updated_at else None,
+    }
+
+
+def _serialize_favorite_minimal(fav) -> dict[str, object]:
+    return {
+        "id": fav.id,
+        "project_id": fav.project_id,
+        "project_ids": [fav.project_id],
+        "item_type": fav.item_type,
+        "item_uuid": fav.item_uuid,
+        "note": fav.note,
+        "context": fav.context,
+        "created_at": fav.created_at.isoformat() if fav.created_at else None,
+        "updated_at": fav.updated_at.isoformat() if fav.updated_at else None,
+    }
+
+
+def _serialize_project(project) -> dict[str, object]:
+    return {
+        "id": project.id,
+        "name": project.name,
+        "color": project.color,
+        "is_default": bool(project.is_default),
+        "sort_order": project.sort_order,
+        "created_at": project.created_at.isoformat() if project.created_at else None,
+    }
+
+
+def _serialize_tag(tag) -> dict[str, object]:
+    return {
+        "id": tag.id,
+        "name": tag.name,
+        "color": tag.color,
+        "created_at": tag.created_at.isoformat() if tag.created_at else None,
+    }
+
+
+def _next_project_sort_order(deps: FavoritesDeps, *, user_id: str) -> int:
+    rows = deps.FavoriteProject.query.filter_by(user_id=user_id).all()
+    if not rows:
+        return 0
+    return max(int(row.sort_order or 0) for row in rows) + 1
+
+
+def _load_tags_for_favorites(
+    deps: FavoritesDeps, *, favorite_ids: list[str]
+) -> dict[str, list[dict[str, object]]]:
+    if not favorite_ids:
+        return {}
+    db_obj = cast(Any, deps.db)
+    session = db_obj.session
+    rows = (
+        session.query(
+            deps.FavoriteTagAssignment.favorite_id,
+            deps.FavoriteTag.id,
+            deps.FavoriteTag.name,
+            deps.FavoriteTag.color,
+        )
+        .join(
+            deps.FavoriteTag,
+            deps.FavoriteTag.id == deps.FavoriteTagAssignment.tag_id,
+        )
+        .filter(
+            deps.FavoriteTagAssignment.favorite_id.in_(favorite_ids)
+        )
+        .order_by(deps.FavoriteTag.name.asc())
+        .all()
+    )
+    out: dict[str, list[dict[str, object]]] = {}
+    for favorite_id, tag_id, name, color in rows:
+        out.setdefault(favorite_id, []).append(
+            {"id": tag_id, "name": name, "color": color}
+        )
+    return out
+
+
+def _load_projects_for_favorites(
+    deps: FavoritesDeps, *, favorite_ids: list[str]
+) -> dict[str, list[str]]:
+    if not favorite_ids:
+        return {}
+    rows = (
+        _db_session(deps)
+        .query(
+            deps.FavoriteProjectAssignment.favorite_id,
+            deps.FavoriteProjectAssignment.project_id,
+        )
+        .filter(deps.FavoriteProjectAssignment.favorite_id.in_(favorite_ids))
+        .all()
+    )
+    out: dict[str, list[str]] = {}
+    for favorite_id, project_id in rows:
+        out.setdefault(favorite_id, []).append(project_id)
+    return out
+
+
+def _ensure_favorite_project_assignment(
+    deps: FavoritesDeps, *, favorite_id: str, project_id: str
+) -> None:
+    existing = deps.FavoriteProjectAssignment.query.filter_by(
+        favorite_id=favorite_id, project_id=project_id
+    ).first()
+    if existing is not None:
+        return
+    assignment = deps.FavoriteProjectAssignment()  # type: ignore[call-arg]
+    assignment.favorite_id = favorite_id
+    assignment.project_id = project_id
+    _db_session(deps).add(assignment)
+
+
+def _backfill_favorite_project_assignments(deps: FavoritesDeps, *, user_id: str) -> None:
+    favorites = deps.Favorite.query.filter_by(user_id=user_id).all()
+    for fav in favorites:
+        _ensure_favorite_project_assignment(
+            deps, favorite_id=fav.id, project_id=fav.project_id
+        )
+
+
+def _resolve_agreement_uuids(
+    deps: FavoritesDeps, *, favorites: list[object]
+) -> dict[tuple[str, str], str]:
+    section_uuids: list[str] = []
+    clause_uuids: list[str] = []
+    agreement_uuids: list[str] = []
+    for fav in favorites:
+        item_type = cast(str, getattr(fav, "item_type"))
+        item_uuid = cast(str, getattr(fav, "item_uuid"))
+        if item_type == "section":
+            section_uuids.append(item_uuid)
+        elif item_type == "tax_clause":
+            clause_uuids.append(item_uuid)
+        elif item_type == "agreement":
+            agreement_uuids.append(item_uuid)
+
+    resolved: dict[tuple[str, str], str] = {}
+    db_obj = cast(Any, deps.db)
+    session = db_obj.session
+
+    if section_uuids:
+        rows = (
+            session.query(deps.Sections.section_uuid, deps.Sections.agreement_uuid)
+            .filter(deps.Sections.section_uuid.in_(section_uuids))
+            .all()
+        )
+        for section_uuid, agreement_uuid in rows:
+            resolved[("section", section_uuid)] = agreement_uuid
+    if clause_uuids:
+        rows = (
+            session.query(deps.Clauses.clause_uuid, deps.Clauses.agreement_uuid)
+            .filter(deps.Clauses.clause_uuid.in_(clause_uuids))
+            .all()
+        )
+        for clause_uuid, agreement_uuid in rows:
+            resolved[("tax_clause", clause_uuid)] = agreement_uuid
+    for agreement_uuid in agreement_uuids:
+        resolved[("agreement", agreement_uuid)] = agreement_uuid
+    return resolved
+
+
+def _no_store(payload: object):
+    resp = make_response(jsonify(payload))
+    resp.headers["Cache-Control"] = "no-store"
+    return resp


### PR DESCRIPTION
## Summary
Convert `backend/routes/favorites.py` to a package and move the 13 module-level helpers out of the main file.

- **`backend/routes/favorites/helpers.py`** (224 LOC) — serializers (`_serialize_favorite`, `_serialize_project`, `_serialize_tag`, etc.), project/tag loaders, agreement-UUID resolver, `_no_store` cache-header wrapper, default-project bootstrap.
- **`backend/routes/favorites/deps.py`** (33 LOC) — the `FavoritesDeps` dataclass, split out so helpers can import the type without circularity.
- **`backend/routes/favorites/__init__.py`** drops from 1135 → 922 LOC. Public surface (`FavoritesDeps`, `register_favorites_routes`) is unchanged.

The route handlers inside `register_favorites_routes` stay together intentionally — they're tightly coupled to closure-captured `deps` and the grouping by entity (projects / favorites / tags / bulk) is already navigable. No further decomposition planned.

## Test plan
- [x] `basedpyright backend/` — 0 errors
- [x] `unittest backend.tests.test_favorites` — 17/17 pass
- [x] Full backend suite — all pass
- [x] Rename preserved at 83% similarity (history kept)