### PR TITLE
Harden /signup/password: fix auth bypass, add captcha/rate limits

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -915,6 +915,9 @@ def _rate_limit_key(ctx: AccessContext) -> tuple[str, int]:
 
 _ENDPOINT_RATE_LIMITS: dict[tuple[str, str], int] = {
     ("POST", "/v1/auth/flag-inaccurate"): 10,
+    ("POST", "/v1/auth/signup/password"): 5,
+    ("POST", "/v1/auth/login/password"): 10,
+    ("POST", "/v1/auth/password-reset/request"): 3,
 }
 
 

--- a/backend/routes/auth/__init__.py
+++ b/backend/routes/auth/__init__.py
@@ -718,7 +718,11 @@ def register_auth_routes(app: Flask, *, deps: AuthDeps) -> Blueprint:
             _send_zitadel_email_verification_for_user(user=user)
             deps.db.session.commit()
             return _verification_required_response(user=user, next_path=next_path)
-        return _auth_success_response(user=user, next_path=next_path)
+        # Fully provisioned accounts must authenticate via /login/password.
+        # Returning a session here would let any caller take over an account
+        # by posting the signup endpoint with the victim's email — the
+        # submitted password is never verified on this path.
+        return None
 
     def _zitadel_email_verify_url_template(*, deps: AuthDeps) -> str:
         return (
@@ -2281,6 +2285,9 @@ window.location.replace({json.dumps(login_url)});
             abort(501, description="Signup is unavailable in mocked auth mode.")
 
         data = deps._load_json(deps.AuthPasswordSignupSchema())
+        if deps._turnstile_enabled():
+            captcha_token = deps._require_captcha_token(data)
+            deps._verify_turnstile_token(token=captcha_token)
         email_raw = data.get("email")
         password = data.get("password")
         first_name = data.get("first_name")
@@ -2329,7 +2336,25 @@ window.location.replace({json.dumps(login_url)});
             )
             if resumed is not None:
                 return resumed
-            abort(409, description="An account with that email already exists. Sign in or reset your password.")
+            # Existing fully-provisioned account. Return the same shape as a
+            # fresh signup so an unauthenticated caller can't use this endpoint
+            # to enumerate registered emails. The real user will be told to
+            # check their email; if no message arrives, they can still sign in
+            # or use the password-reset flow.
+            current_app.logger.info(
+                "signup_password_existing_account_masked email=%s", email
+            )
+            resp = make_response(
+                jsonify(
+                    {
+                        "status": "verification_required",
+                        "next_path": next_path,
+                        "user": {"id": "", "email": email},
+                    }
+                )
+            )
+            resp.headers["Cache-Control"] = "no-store"
+            return resp
 
         try:
             external_identity = _create_zitadel_human_user(
@@ -2501,6 +2526,9 @@ window.location.replace({json.dumps(login_url)});
             abort(501, description="Password reset is unavailable in mocked auth mode.")
 
         data = deps._load_json(deps.AuthPasswordResetRequestSchema())
+        if deps._turnstile_enabled():
+            captcha_token = deps._require_captcha_token(data)
+            deps._verify_turnstile_token(token=captcha_token)
         email_raw = data.get("email")
         if not isinstance(email_raw, str) or not email_raw.strip():
             abort(400, description="Email is required.")

--- a/backend/routes/auth/__init__.py
+++ b/backend/routes/auth/__init__.py
@@ -2338,9 +2338,10 @@ window.location.replace({json.dumps(login_url)});
                 return resumed
             # Existing fully-provisioned account. Return the same shape as a
             # fresh signup so an unauthenticated caller can't use this endpoint
-            # to enumerate registered emails. The real user will be told to
-            # check their email; if no message arrives, they can still sign in
-            # or use the password-reset flow.
+            # to enumerate registered emails. The id is a throwaway UUID so the
+            # response is shape-indistinguishable from a legitimate new signup.
+            # The real user will be told to check their email; if no message
+            # arrives, they can sign in or use the password-reset flow.
             current_app.logger.info(
                 "signup_password_existing_account_masked email=%s", email
             )
@@ -2349,7 +2350,7 @@ window.location.replace({json.dumps(login_url)});
                     {
                         "status": "verification_required",
                         "next_path": next_path,
-                        "user": {"id": "", "email": email},
+                        "user": {"id": str(uuid.uuid4()), "email": email},
                     }
                 )
             )

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -23,10 +23,12 @@ class AuthPasswordSignupSchema(Schema):
     first_name = fields.Str(required=False, allow_none=True)
     last_name = fields.Str(required=False, allow_none=True)
     next = fields.Str(required=False, allow_none=True)
+    captcha_token = fields.Str(required=False, allow_none=True)
 
 
 class AuthPasswordResetRequestSchema(Schema):
     email = fields.Email(required=True)
+    captcha_token = fields.Str(required=False, allow_none=True)
 
 
 class AuthPasswordResetConfirmSchema(Schema):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1832,7 +1832,14 @@ class AuthFlowTests(unittest.TestCase):
         payload = res.get_json()
         self.assertEqual(payload["status"], "verification_required")
         self.assertEqual(payload["user"]["email"], "taken@example.com")
-        self.assertEqual(payload["user"]["id"], "")
+        # Masked response must mint a throwaway UUID, not echo the real user
+        # id and not return an obviously-fake empty string — both would let
+        # an unauthenticated caller distinguish "existing" from "new".
+        masked_id = payload["user"]["id"]
+        self.assertIsInstance(masked_id, str)
+        self.assertNotEqual(masked_id, user_id)
+        self.assertNotEqual(masked_id, "")
+        self.assertEqual(len(masked_id), 36)
 
     def test_password_signup_requires_captcha_token_when_turnstile_enabled(self):
         os.environ["AUTH_SESSION_TRANSPORT"] = "bearer"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1791,6 +1791,73 @@ class AuthFlowTests(unittest.TestCase):
         self.assertEqual(payload["status"], "legal_required")
         self.assertEqual(payload["user"]["email"], "resume-signup@example.com")
 
+    def test_password_signup_masks_existing_verified_account_to_prevent_enumeration(self):
+        os.environ["AUTH_SESSION_TRANSPORT"] = "bearer"
+        client = self.app.test_client()
+        with self.app.app_context():
+            user_id = self._create_local_user(
+                email="taken@example.com",
+                password="Secr3tP4ss!",
+                verified=True,
+                legal=True,
+            )
+            db.session.add(
+                self._auth_external_subject(
+                    user_id=user_id,
+                    issuer="https://pandects-test-zitadel.example.com",
+                    subject="zitadel-taken-user",
+                )
+            )
+            db.session.commit()
+
+        original_oauth_fetch_json = backend_app._oauth_fetch_json
+
+        def _fail_oauth_fetch_json(*args, **kwargs):
+            self.fail("Masked-existing-account signup must not call the remote auth provider.")
+
+        backend_app._oauth_fetch_json = _fail_oauth_fetch_json
+        try:
+            res = client.post(
+                "/v1/auth/signup/password",
+                json={
+                    "email": "taken@example.com",
+                    "password": "AnotherP4ss!",
+                    "next": "/account",
+                },
+            )
+        finally:
+            backend_app._oauth_fetch_json = original_oauth_fetch_json
+
+        self.assertEqual(res.status_code, 200)
+        payload = res.get_json()
+        self.assertEqual(payload["status"], "verification_required")
+        self.assertEqual(payload["user"]["email"], "taken@example.com")
+        self.assertEqual(payload["user"]["id"], "")
+
+    def test_password_signup_requires_captcha_token_when_turnstile_enabled(self):
+        os.environ["AUTH_SESSION_TRANSPORT"] = "bearer"
+        os.environ["TURNSTILE_ENABLED"] = "1"
+        os.environ["TURNSTILE_SITE_KEY"] = "test-site-key"
+        os.environ["TURNSTILE_SECRET_KEY"] = "test-secret-key"
+        client = self.app.test_client()
+        try:
+            res = client.post(
+                "/v1/auth/signup/password",
+                json={
+                    "email": "needs-captcha@example.com",
+                    "password": "Secr3tP4ss!",
+                    "next": "/account",
+                },
+            )
+        finally:
+            os.environ.pop("TURNSTILE_ENABLED", None)
+            os.environ.pop("TURNSTILE_SITE_KEY", None)
+            os.environ.pop("TURNSTILE_SECRET_KEY", None)
+
+        self.assertEqual(res.status_code, 412)
+        payload = res.get_json()
+        self.assertEqual(payload["error"], "captcha_required")
+
     def test_password_signup_pending_no_legal_and_unverified_returns_legal_required(self):
         os.environ["AUTH_SESSION_TRANSPORT"] = "bearer"
         os.environ["AUTH_ZITADEL_API_TOKEN"] = "test-zitadel-api-token"

--- a/frontend/client/lib/auth-api.ts
+++ b/frontend/client/lib/auth-api.ts
@@ -137,6 +137,7 @@ export async function signupWithPassword(payload: {
   first_name?: string;
   last_name?: string;
   next?: string;
+  captcha_token?: string;
 }) {
   return authFetchJson<WebsiteAuthResult>(apiUrl("v1/auth/signup/password"), {
     method: "POST",
@@ -145,12 +146,23 @@ export async function signupWithPassword(payload: {
   });
 }
 
-export async function requestPasswordReset(payload: { email: string }) {
+export async function requestPasswordReset(payload: {
+  email: string;
+  captcha_token?: string;
+}) {
   return authFetchJson<{ status: "requested" }>(apiUrl("v1/auth/password-reset/request"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
+}
+
+export type CaptchaSiteKeyResponse =
+  | { enabled: false }
+  | { enabled: true; site_key: string };
+
+export async function fetchCaptchaSiteKey() {
+  return authFetchJson<CaptchaSiteKeyResponse>(apiUrl("v1/auth/captcha/site-key"));
 }
 
 export async function confirmPasswordReset(payload: {

--- a/frontend/client/pages/ResetPassword.tsx
+++ b/frontend/client/pages/ResetPassword.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label";
 import { useAuth } from "@/hooks/use-auth";
 import { fetchCaptchaSiteKey, requestPasswordReset } from "@/lib/auth-api";
 import { navigateToNextPath, nextPathRequiresDocumentNavigation, safeNextPath } from "@/lib/auth-next";
+import { withAuthWakeRetry } from "@/lib/auth-wake";
 
 export default function ResetPassword() {
   const { status } = useAuth();
@@ -25,17 +26,19 @@ export default function ResetPassword() {
   const [error, setError] = useState<string | null>(null);
   const [captchaSiteKey, setCaptchaSiteKey] = useState<string | null>(null);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const [captchaResolved, setCaptchaResolved] = useState(false);
 
   useEffect(() => {
     let canceled = false;
-    void fetchCaptchaSiteKey()
+    void withAuthWakeRetry(() => fetchCaptchaSiteKey())
       .then((result) => {
         if (canceled) return;
         if (result.enabled) setCaptchaSiteKey(result.site_key);
+        setCaptchaResolved(true);
       })
       .catch(() => {
-        // Site-key endpoint failure leaves captcha disabled; the BE will
-        // reject the submit with a clear 412 if captcha is actually required.
+        if (canceled) return;
+        setCaptchaResolved(true);
       });
     return () => {
       canceled = true;
@@ -120,7 +123,11 @@ export default function ResetPassword() {
             <div className="flex justify-center pt-1">
               <Button
                 type="submit"
-                disabled={submitting || (captchaSiteKey !== null && !captchaToken)}
+                disabled={
+                  submitting ||
+                  !captchaResolved ||
+                  (captchaSiteKey !== null && !captchaToken)
+                }
                 className="min-w-[10rem] rounded-full px-6"
               >
                 {submitting ? "Sending reset link…" : "Send reset link"}

--- a/frontend/client/pages/ResetPassword.tsx
+++ b/frontend/client/pages/ResetPassword.tsx
@@ -1,13 +1,14 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
 import { PageShell } from "@/components/PageShell";
+import { TurnstileWidget } from "@/components/TurnstileWidget";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAuth } from "@/hooks/use-auth";
-import { requestPasswordReset } from "@/lib/auth-api";
+import { fetchCaptchaSiteKey, requestPasswordReset } from "@/lib/auth-api";
 import { navigateToNextPath, nextPathRequiresDocumentNavigation, safeNextPath } from "@/lib/auth-next";
 
 export default function ResetPassword() {
@@ -22,6 +23,24 @@ export default function ResetPassword() {
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [captchaSiteKey, setCaptchaSiteKey] = useState<string | null>(null);
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    let canceled = false;
+    void fetchCaptchaSiteKey()
+      .then((result) => {
+        if (canceled) return;
+        if (result.enabled) setCaptchaSiteKey(result.site_key);
+      })
+      .catch(() => {
+        // Site-key endpoint failure leaves captcha disabled; the BE will
+        // reject the submit with a clear 412 if captcha is actually required.
+      });
+    return () => {
+      canceled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (status !== "authenticated" || !nextPathRequiresDocumentNavigation(nextPath)) {
@@ -42,7 +61,7 @@ export default function ResetPassword() {
     setSubmitting(true);
     setError(null);
     try {
-      await requestPasswordReset({ email });
+      await requestPasswordReset({ email, captcha_token: captchaToken ?? undefined });
       setSubmitted(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -91,8 +110,19 @@ export default function ResetPassword() {
                 className="h-11 border-border bg-background"
               />
             </div>
+            {captchaSiteKey ? (
+              <TurnstileWidget
+                siteKey={captchaSiteKey}
+                onToken={setCaptchaToken}
+                onError={setError}
+              />
+            ) : null}
             <div className="flex justify-center pt-1">
-              <Button type="submit" disabled={submitting} className="min-w-[10rem] rounded-full px-6">
+              <Button
+                type="submit"
+                disabled={submitting || (captchaSiteKey !== null && !captchaToken)}
+                className="min-w-[10rem] rounded-full px-6"
+              >
                 {submitting ? "Sending reset link…" : "Send reset link"}
               </Button>
             </div>

--- a/frontend/client/pages/Signup.tsx
+++ b/frontend/client/pages/Signup.tsx
@@ -72,6 +72,7 @@ export default function Signup() {
   const [legalCheckedAtMs, setLegalCheckedAtMs] = useState<number | null>(null);
   const [captchaSiteKey, setCaptchaSiteKey] = useState<string | null>(null);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const [captchaResolved, setCaptchaResolved] = useState(false);
 
   useEffect(() => {
     void prewarmAuthBackend();
@@ -79,14 +80,18 @@ export default function Signup() {
 
   useEffect(() => {
     let canceled = false;
-    void fetchCaptchaSiteKey()
+    void withAuthWakeRetry(() => fetchCaptchaSiteKey())
       .then((result) => {
         if (canceled) return;
         if (result.enabled) setCaptchaSiteKey(result.site_key);
+        setCaptchaResolved(true);
       })
       .catch(() => {
-        // Site-key endpoint failure leaves captcha disabled; the BE will
-        // reject the submit with a clear 412 if captcha is actually required.
+        if (canceled) return;
+        // Mark resolved so the submit button is no longer indefinitely
+        // disabled; if the BE actually requires captcha, the submit will
+        // surface a clear 412 captcha_required error.
+        setCaptchaResolved(true);
       });
     return () => {
       canceled = true;
@@ -345,7 +350,11 @@ export default function Signup() {
                 <div className="flex justify-center pt-1">
                   <Button
                     type="submit"
-                    disabled={submitting || (captchaSiteKey !== null && !captchaToken)}
+                    disabled={
+                      submitting ||
+                      !captchaResolved ||
+                      (captchaSiteKey !== null && !captchaToken)
+                    }
                     className="min-w-[12rem] rounded-full px-6"
                   >
                     {submitting ? (

--- a/frontend/client/pages/Signup.tsx
+++ b/frontend/client/pages/Signup.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useMemo, useState } from "react";
 import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
 import { PageShell } from "@/components/PageShell";
 import { LegalAcceptancePrompt } from "@/components/auth/LegalAcceptancePrompt";
+import { TurnstileWidget } from "@/components/TurnstileWidget";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -10,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { useAuth } from "@/hooks/use-auth";
 import {
+  fetchCaptchaSiteKey,
   finalizeZitadelWebsiteAuth,
   signupWithPassword,
   startZitadelGoogleWebsiteAuth,
@@ -68,9 +70,27 @@ export default function Signup() {
   const [error, setError] = useState<string | null>(null);
   const [legalAccepted, setLegalAccepted] = useState(false);
   const [legalCheckedAtMs, setLegalCheckedAtMs] = useState<number | null>(null);
+  const [captchaSiteKey, setCaptchaSiteKey] = useState<string | null>(null);
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
 
   useEffect(() => {
     void prewarmAuthBackend();
+  }, []);
+
+  useEffect(() => {
+    let canceled = false;
+    void fetchCaptchaSiteKey()
+      .then((result) => {
+        if (canceled) return;
+        if (result.enabled) setCaptchaSiteKey(result.site_key);
+      })
+      .catch(() => {
+        // Site-key endpoint failure leaves captcha disabled; the BE will
+        // reject the submit with a clear 412 if captcha is actually required.
+      });
+    return () => {
+      canceled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -112,6 +132,7 @@ export default function Signup() {
         first_name: firstName || undefined,
         last_name: lastName || undefined,
         next: nextPath,
+        captcha_token: captchaToken ?? undefined,
       });
       if (result.status === "legal_required") {
         setState({
@@ -314,10 +335,17 @@ export default function Signup() {
                   When you continue, you'll be prompted to accept our terms; then, you can finish
                   activation by verifying your email address.
                 </p>
+                {captchaSiteKey ? (
+                  <TurnstileWidget
+                    siteKey={captchaSiteKey}
+                    onToken={setCaptchaToken}
+                    onError={setError}
+                  />
+                ) : null}
                 <div className="flex justify-center pt-1">
                   <Button
                     type="submit"
-                    disabled={submitting}
+                    disabled={submitting || (captchaSiteKey !== null && !captchaToken)}
                     className="min-w-[12rem] rounded-full px-6"
                   >
                     {submitting ? (


### PR DESCRIPTION
## Summary

- **Auth bypass fix (critical):** `_resume_incomplete_signup_if_eligible` returned an authenticated session for fully-provisioned accounts without verifying the submitted password. Any caller could take over an account by POSTing `/v1/auth/signup/password` with the victim's email and any password. Fully provisioned accounts now fall through and must use `/login/password`.
- **Captcha enforcement:** Turnstile verification is now invoked in `/signup/password` and `/password-reset/request` when `TURNSTILE_ENABLED`. The runtime was already wired through `AuthDeps` but never called.
- **Endpoint rate limits:** Per-IP caps added to `_ENDPOINT_RATE_LIMITS` — signup 5/min, login 10/min, password-reset 3/min. Previously only the global 60/min anon cap applied.
- **Email enumeration fix:** the `409 "An account with that email already exists"` response on `/signup/password` is replaced with the same `verification_required` shape returned for new signups, removing the enumeration oracle.
- Schemas now accept `captcha_token`.

## Test plan

- [x] `backend.tests.test_auth` — 68/68 pass, including two new tests:
  - `test_password_signup_masks_existing_verified_account_to_prevent_enumeration` — asserts existing fully-provisioned account returns `verification_required` (not 200 `authenticated`, not 409) with no user-id leak.
  - `test_password_signup_requires_captcha_token_when_turnstile_enabled` — asserts 412 `captcha_required` when Turnstile is enabled and no token is supplied.
- [x] Full backend suite: 257/257 pass.
- [x] `basedpyright backend/`: 0 errors.
- [ ] Manually verify the frontend signup page still shows the "check your email" state when re-submitting an email that already has a fully provisioned account.
- [ ] Confirm Turnstile site-key endpoint and FE widget submit `captcha_token` once `TURNSTILE_ENABLED=1` is set in prod env.

## Rollout notes

- Captcha enforcement is gated on `turnstile_enabled()`, which requires `TURNSTILE_ENABLED=1` (or Fly + both keys set). Existing dev/test envs are unaffected.
- The bypass fix removes a path that was reachable by any caller knowing a registered email — worth deploying ASAP.