### PR TITLE
Rate-limit OAuth client registration; bump urllib3 to 2.7.0

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -918,6 +918,7 @@ _ENDPOINT_RATE_LIMITS: dict[tuple[str, str], int] = {
     ("POST", "/v1/auth/signup/password"): 5,
     ("POST", "/v1/auth/login/password"): 10,
     ("POST", "/v1/auth/password-reset/request"): 3,
+    ("POST", "/v1/auth/oauth/register"): 10,
 }
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -31,6 +31,6 @@ s3transfer==0.13.0
 six==1.17.0
 SQLAlchemy==2.0.41
 typing_extensions==4.14.0
-urllib3==2.6.3
+urllib3==2.7.0
 webargs==8.7.0
 Werkzeug==3.1.3

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -3298,6 +3298,25 @@ class AuthFlowTests(unittest.TestCase):
             ["authorization_code", "refresh_token"],
         )
 
+    def test_oauth_register_is_rate_limited_per_ip(self):
+        os.environ["AUTH_SESSION_TRANSPORT"] = "bearer"
+        client = self.app.test_client()
+
+        payload = {
+            "client_name": "Codex MCP",
+            "redirect_uris": ["https://codex.example.com/callback"],
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+        }
+        limit = backend_app._ENDPOINT_RATE_LIMITS[("POST", "/v1/auth/oauth/register")]
+        statuses = [
+            client.post("/v1/auth/oauth/register", json=payload).status_code
+            for _ in range(limit + 1)
+        ]
+        self.assertTrue(all(code == 201 for code in statuses[:limit]), statuses)
+        self.assertEqual(statuses[-1], 429)
+
     def test_oauth_register_rejects_unsafe_redirect_uris(self):
         client = self.app.test_client()
 

--- a/etl/uv.lock
+++ b/etl/uv.lock
@@ -3171,11 +3171,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Rate-limit `/v1/auth/oauth/register`** (10/min per IP). RFC 7591 dynamic client registration is intentionally unauthenticated, so without an endpoint cap a single IP could create OAuth client rows unbounded under the global 60/min anon limit. Mirrors the per-endpoint caps added in #63 for signup/login/password-reset.
- **Bump urllib3 2.6.3 → 2.7.0** in `backend/requirements.txt` and `etl/uv.lock`, clearing two advisories:
  - Sensitive headers forwarded across origins on proxied low-level redirects (relevant: the backend makes outbound redirect-following calls to Zitadel, Cloudflare Turnstile, and Resend).
  - Decompression-bomb safeguards bypassed in parts of the streaming API.

## Test plan

- [x] New test `test_oauth_register_is_rate_limited_per_ip` asserts the 11th registration in a minute returns 429.
- [x] Full backend suite: 258/258 pass.
- [x] `basedpyright backend/`: 0 errors.
- [x] `pip check` clean with urllib3 2.7.0.
- [x] `etl/uv.lock` change is urllib3-only (verified no unrelated dependency drift).

## Notes

- The etl lock change is scoped to urllib3. A separate, unrelated pending change adds `pyyaml` as a direct etl dependency; that is intentionally **not** included here and remains for its own change.