### PR TITLE
Security medium tier A: enumeration delay, captcha fail-closed, swagger gate, defusedxml

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -141,6 +141,7 @@ from backend.core.runtime_utils import (
 )
 from backend.auth.captcha_runtime import (
     require_captcha_token as _require_captcha_token,
+    require_turnstile_configured as _require_turnstile_configured,
     turnstile_enabled as _turnstile_enabled,
     turnstile_site_key as _turnstile_site_key,
     verify_turnstile_token as _verify_turnstile_token,
@@ -1445,6 +1446,7 @@ def _build_route_deps() -> tuple[SectionsDeps, AgreementsDeps, ReferenceDataDeps
         _set_csrf_cookie=_set_csrf_cookie,
         _status_response=_status_response,
         _turnstile_enabled=_turnstile_enabled,
+        _require_turnstile_configured=_require_turnstile_configured,
         _turnstile_site_key=_turnstile_site_key,
         _user_has_current_legal_acceptances=_user_has_current_legal_acceptances,
         _utc_now=_utc_now,

--- a/backend/auth/captcha_runtime.py
+++ b/backend/auth/captcha_runtime.py
@@ -27,6 +27,21 @@ def turnstile_enabled() -> bool:
     )
 
 
+def turnstile_required() -> bool:
+    # In production (Fly) we want captcha to be a hard requirement on the
+    # high-abuse endpoints. If the keys are missing on Fly we'd rather refuse
+    # the request than silently fall back to "no captcha".
+    raw = os.environ.get("TURNSTILE_ENABLED", "").strip()
+    if raw == "0":
+        return False
+    return is_running_on_fly()
+
+
+def require_turnstile_configured() -> None:
+    if turnstile_required() and not turnstile_enabled():
+        abort(503, description="Captcha is not configured (missing TURNSTILE keys).")
+
+
 def turnstile_site_key() -> str:
     site_key = os.environ.get("TURNSTILE_SITE_KEY", "").strip()
     if not site_key:

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -142,31 +142,45 @@ def max_content_length() -> int:
     return 1 * 1024 * 1024
 
 
+def _expose_swagger_ui() -> bool:
+    # Swagger UI pulls scripts from cdn.jsdelivr.net (not in our CSP) and
+    # enumerates every authenticated endpoint with parameter schemas — useful
+    # recon. Keep it on by default for local dev, opt-in on Fly.
+    raw = os.environ.get("EXPOSE_SWAGGER_UI", "").strip()
+    if raw == "1":
+        return True
+    if raw == "0":
+        return False
+    from backend.auth.session_runtime import is_running_on_fly
+
+    return not is_running_on_fly()
+
+
 def configure_openapi(target_app: Flask) -> None:
     config = app_config_map(target_app)
-    config.update(
-        {
-            "API_TITLE": "Pandects API",
-            "API_VERSION": "v1",
-            "OPENAPI_VERSION": "3.0.2",
-            "API_SPEC_OPTIONS": {
-                "servers": [
-                    {
-                        "url": "https://api.pandects.org",
-                        "description": "Production API",
-                    },
-                    {
-                        "url": "http://localhost:5113",
-                        "description": "Local development API",
-                    },
-                ]
-            },
-            "OPENAPI_URL_PREFIX": "/",
-            "OPENAPI_SWAGGER_UI_PATH": "/swagger-ui",
-            "OPENAPI_SWAGGER_UI_URL": "https://cdn.jsdelivr.net/npm/swagger-ui-dist/",
-            "MAX_CONTENT_LENGTH": None,
-        }
-    )
+    openapi_config: dict[str, object] = {
+        "API_TITLE": "Pandects API",
+        "API_VERSION": "v1",
+        "OPENAPI_VERSION": "3.0.2",
+        "API_SPEC_OPTIONS": {
+            "servers": [
+                {
+                    "url": "https://api.pandects.org",
+                    "description": "Production API",
+                },
+                {
+                    "url": "http://localhost:5113",
+                    "description": "Local development API",
+                },
+            ]
+        },
+        "OPENAPI_URL_PREFIX": "/",
+        "MAX_CONTENT_LENGTH": None,
+    }
+    if _expose_swagger_ui():
+        openapi_config["OPENAPI_SWAGGER_UI_PATH"] = "/swagger-ui"
+        openapi_config["OPENAPI_SWAGGER_UI_URL"] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist/"
+    config.update(openapi_config)
     config["MAX_CONTENT_LENGTH"] = max_content_length()
 
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -146,14 +146,17 @@ def _expose_swagger_ui() -> bool:
     # Swagger UI pulls scripts from cdn.jsdelivr.net (not in our CSP) and
     # enumerates every authenticated endpoint with parameter schemas — useful
     # recon. Keep it on by default for local dev, opt-in on Fly.
+    #
+    # Fly detection is inlined (rather than importing is_running_on_fly from
+    # backend.auth.session_runtime) because session_runtime already imports
+    # from this module — pulling it back the other way creates a cycle.
     raw = os.environ.get("EXPOSE_SWAGGER_UI", "").strip()
     if raw == "1":
         return True
     if raw == "0":
         return False
-    from backend.auth.session_runtime import is_running_on_fly
-
-    return not is_running_on_fly()
+    on_fly = bool(os.environ.get("FLY_APP_NAME") or os.environ.get("FLY_REGION"))
+    return not on_fly
 
 
 def configure_openapi(target_app: Flask) -> None:

--- a/backend/redaction.py
+++ b/backend/redaction.py
@@ -1,4 +1,9 @@
+# Parse with defusedxml to harden against billion-laughs / quadratic-blowup
+# even though today's input is trusted (own DB). Serialize with stdlib ET —
+# defusedxml does not provide a tostring/SubElement constructor.
 import xml.etree.ElementTree as ET
+
+import defusedxml.ElementTree as DET
 
 
 def redact_agreement_xml(
@@ -12,7 +17,7 @@ def redact_agreement_xml(
             return tag.rsplit("}", 1)[-1]
         return tag
 
-    root = ET.fromstring(xml_content)
+    root = DET.fromstring(xml_content)
     sections: list[ET.Element] = [
         el for el in root.iter() if _local_name(el.tag).lower() == "section"
     ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ botocore==1.39.8
 cffi==2.0.0
 click==8.2.1
 cryptography==44.0.0
+defusedxml==0.7.1
 Flask==3.1.1
 flask-cors==6.0.1
 flask-smorest==0.46.1

--- a/backend/routes/auth/__init__.py
+++ b/backend/routes/auth/__init__.py
@@ -2466,6 +2466,9 @@ window.location.replace({json.dumps(login_url)});
                 issuer=mcp_oidc_issuer(),
             ).first()
             if existing_link is not None:
+                # Local fast-path that reveals "this email has an account" —
+                # delay so the timing matches a real Zitadel round-trip.
+                deps._auth_enumeration_delay()
                 _pending_login_block_response(user=existing_user, next_path=next_path)
 
         try:
@@ -2473,6 +2476,9 @@ window.location.replace({json.dumps(login_url)});
                 external_identity = _zitadel_session_identity(email=email, password=password)
             except HTTPException as exc:
                 if exc.code == 400 and exc.description == "Verify your email before signing in.":
+                    # Reveals "account exists but unverified". Equalize timing
+                    # with the invalid-credentials path below.
+                    deps._auth_enumeration_delay()
                     raise
                 if exc.code in {400, 401, 403, 404, 409}:
                     migrated = _maybe_migrate_local_password_user(email=email, password=password)
@@ -2513,6 +2519,10 @@ window.location.replace({json.dumps(login_url)});
             abort(501, description="Signup is unavailable in mocked auth mode.")
 
         data = deps._load_json(deps.AuthPasswordSignupSchema())
+        # Fail-closed on production deployments where Turnstile keys are
+        # missing — better to surface a 503 than to silently lose the captcha
+        # gate on a high-abuse endpoint.
+        deps._require_turnstile_configured()
         if deps._turnstile_enabled():
             captcha_token = deps._require_captcha_token(data)
             deps._verify_turnstile_token(token=captcha_token)
@@ -2755,6 +2765,7 @@ window.location.replace({json.dumps(login_url)});
             abort(501, description="Password reset is unavailable in mocked auth mode.")
 
         data = deps._load_json(deps.AuthPasswordResetRequestSchema())
+        deps._require_turnstile_configured()
         if deps._turnstile_enabled():
             captcha_token = deps._require_captcha_token(data)
             deps._verify_turnstile_token(token=captcha_token)

--- a/backend/routes/auth/__init__.py
+++ b/backend/routes/auth/__init__.py
@@ -889,12 +889,22 @@ def register_auth_routes(app: Flask, *, deps: AuthDeps) -> Blueprint:
 
     def _pending_login_block_response(*, user, next_path: str):
         has_legal = deps._user_has_current_legal_acceptances(user_id=user.id)
+        blocked_reason: str | None = None
         if user.email_verified_at is None and not has_legal:
-            abort(400, description="You need to accept the terms and verify your email before signing in.")
-        if user.email_verified_at is None:
-            abort(400, description="Verify your email before signing in.")
-        if not has_legal:
-            abort(400, description="You need to accept the terms before signing in.")
+            blocked_reason = "You need to accept the terms and verify your email before signing in."
+        elif user.email_verified_at is None:
+            blocked_reason = "Verify your email before signing in."
+        elif not has_legal:
+            blocked_reason = "You need to accept the terms before signing in."
+        if blocked_reason is not None:
+            # All three abort branches reveal "account exists with a Zitadel
+            # link" via a local fast-path. Delay so the timing matches a real
+            # Zitadel round-trip. Pay the delay only on the abort path —
+            # adding it to the helper's pass-through (verified + legal user)
+            # would slow the legitimate login by ~250ms and create a new
+            # timing oracle vs. the no-link path.
+            deps._auth_enumeration_delay()
+            abort(400, description=blocked_reason)
         return None
 
     def _ensure_pending_signup_user(
@@ -2466,9 +2476,11 @@ window.location.replace({json.dumps(login_url)});
                 issuer=mcp_oidc_issuer(),
             ).first()
             if existing_link is not None:
-                # Local fast-path that reveals "this email has an account" —
-                # delay so the timing matches a real Zitadel round-trip.
-                deps._auth_enumeration_delay()
+                # Helper aborts with 400 when this account is pending
+                # (unverified email / missing legal). The helper internally
+                # delays before aborting so the abort-vs-Zitadel timing is
+                # indistinguishable. If it returns None we continue to the
+                # real Zitadel call without an artificial delay.
                 _pending_login_block_response(user=existing_user, next_path=next_path)
 
         try:

--- a/backend/routes/deps.py
+++ b/backend/routes/deps.py
@@ -330,6 +330,7 @@ class AuthDeps:
     _set_csrf_cookie: SetCsrfCookieProtocol
     _status_response: StatusResponseProtocol
     _turnstile_enabled: Callable[[], bool]
+    _require_turnstile_configured: Callable[[], None]
     _turnstile_site_key: Callable[[], str]
     _user_has_current_legal_acceptances: UserHasCurrentLegalAcceptancesProtocol
     _utc_now: Callable[[], datetime]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -4437,6 +4437,97 @@ class AuthFlowTests(unittest.TestCase):
         )
         self.assertEqual(res.status_code, 404)
 
+    def test_password_login_pending_block_path_invokes_enumeration_delay(self):
+        # Verified-but-no-legal user with a Zitadel link triggers the local
+        # fast-path that reveals account existence. We need the randomized
+        # delay to fire so its timing matches a real Zitadel round-trip.
+        os.environ["AUTH_SESSION_TRANSPORT"] = "bearer"
+        client = self.app.test_client()
+        with self.app.app_context():
+            user_id = self._create_local_user(
+                email="pending-block@example.com",
+                verified=True,
+                legal=False,
+            )
+            db.session.add(
+                self._auth_external_subject(
+                    user_id=user_id,
+                    issuer="https://pandects-test-zitadel.example.com",
+                    subject="zitadel-pending-block-user",
+                )
+            )
+            db.session.commit()
+
+        from unittest.mock import patch
+
+        with patch("backend.app.time.sleep") as sleep_mock:
+            res = client.post(
+                "/v1/auth/login/password",
+                json={
+                    "email": "pending-block@example.com",
+                    "password": "password123",
+                },
+            )
+
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("terms", (res.get_json() or {}).get("message", "").lower())
+        sleep_mock.assert_called()
+
+    def test_password_reset_request_fails_closed_when_turnstile_unconfigured_on_fly(self):
+        # On Fly (production proxy) we want hard 503 if TURNSTILE keys are
+        # missing rather than silently dropping the captcha gate.
+        os.environ["FLY_APP_NAME"] = "pandects-test"
+        _ = os.environ.pop("TURNSTILE_ENABLED", None)
+        _ = os.environ.pop("TURNSTILE_SITE_KEY", None)
+        _ = os.environ.pop("TURNSTILE_SECRET_KEY", None)
+        client = self.app.test_client()
+        try:
+            res = client.post(
+                "/v1/auth/password-reset/request",
+                json={"email": "reset-fail-closed@example.com"},
+            )
+        finally:
+            os.environ.pop("FLY_APP_NAME", None)
+
+        self.assertEqual(res.status_code, 503)
+
+    def test_password_signup_fails_closed_when_turnstile_unconfigured_on_fly(self):
+        os.environ["FLY_APP_NAME"] = "pandects-test"
+        _ = os.environ.pop("TURNSTILE_ENABLED", None)
+        _ = os.environ.pop("TURNSTILE_SITE_KEY", None)
+        _ = os.environ.pop("TURNSTILE_SECRET_KEY", None)
+        client = self.app.test_client()
+        try:
+            res = client.post(
+                "/v1/auth/signup/password",
+                json={
+                    "email": "signup-fail-closed@example.com",
+                    "password": "Secr3tP4ss!",
+                    "next": "/account",
+                },
+            )
+        finally:
+            os.environ.pop("FLY_APP_NAME", None)
+
+        self.assertEqual(res.status_code, 503)
+
+    def test_password_reset_request_allowed_when_turnstile_explicitly_disabled(self):
+        # Explicit opt-out (TURNSTILE_ENABLED=0) must keep working even on Fly
+        # so the operator can disable captcha for a specific deployment.
+        os.environ["FLY_APP_NAME"] = "pandects-test"
+        os.environ["TURNSTILE_ENABLED"] = "0"
+        client = self.app.test_client()
+        try:
+            res = client.post(
+                "/v1/auth/password-reset/request",
+                json={"email": "no-such-account@example.com"},
+            )
+        finally:
+            os.environ.pop("FLY_APP_NAME", None)
+            os.environ["TURNSTILE_ENABLED"] = "0"
+
+        self.assertEqual(res.status_code, 200)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_openapi_config.py
+++ b/backend/tests/test_openapi_config.py
@@ -1,0 +1,55 @@
+import os
+import unittest
+
+
+class ExposeSwaggerUiTests(unittest.TestCase):
+    """Swagger UI pulls scripts from cdn.jsdelivr.net (not in our /v1 CSP) and
+    enumerates every authenticated endpoint with parameter schemas. Keep it on
+    by default for local dev but off on Fly unless explicitly opted in."""
+
+    _saved_fly: str | None = None
+    _saved_region: str | None = None
+    _saved_expose: str | None = None
+
+    def setUp(self) -> None:
+        self._saved_fly = os.environ.pop("FLY_APP_NAME", None)
+        self._saved_region = os.environ.pop("FLY_REGION", None)
+        self._saved_expose = os.environ.pop("EXPOSE_SWAGGER_UI", None)
+
+    def tearDown(self) -> None:
+        for k in ("FLY_APP_NAME", "FLY_REGION", "EXPOSE_SWAGGER_UI"):
+            os.environ.pop(k, None)
+        if self._saved_fly is not None:
+            os.environ["FLY_APP_NAME"] = self._saved_fly
+        if self._saved_region is not None:
+            os.environ["FLY_REGION"] = self._saved_region
+        if self._saved_expose is not None:
+            os.environ["EXPOSE_SWAGGER_UI"] = self._saved_expose
+
+    def test_local_dev_exposes_swagger_ui(self) -> None:
+        from backend.core.config import _expose_swagger_ui
+
+        self.assertTrue(_expose_swagger_ui())
+
+    def test_fly_hides_swagger_ui_by_default(self) -> None:
+        os.environ["FLY_APP_NAME"] = "pandects-test"
+        from backend.core.config import _expose_swagger_ui
+
+        self.assertFalse(_expose_swagger_ui())
+
+    def test_fly_with_explicit_opt_in_exposes_swagger_ui(self) -> None:
+        os.environ["FLY_APP_NAME"] = "pandects-test"
+        os.environ["EXPOSE_SWAGGER_UI"] = "1"
+        from backend.core.config import _expose_swagger_ui
+
+        self.assertTrue(_expose_swagger_ui())
+
+    def test_explicit_opt_out_hides_swagger_ui_even_locally(self) -> None:
+        os.environ["EXPOSE_SWAGGER_UI"] = "0"
+        from backend.core.config import _expose_swagger_ui
+
+        self.assertFalse(_expose_swagger_ui())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_redaction.py
+++ b/backend/tests/test_redaction.py
@@ -66,6 +66,21 @@ class TestXmlRedaction(unittest.TestCase):
         with self.assertRaises(ValueError):
             redact_agreement_xml("<document/>", focus_section_uuid=None, neighbor_sections=6)
 
+    def test_billion_laughs_rejected_by_defusedxml(self) -> None:
+        # defusedxml refuses entity expansion attacks even when the input is
+        # technically well-formed XML. Confirms the parser swap took effect.
+        from defusedxml.common import EntitiesForbidden
+
+        bomb = (
+            '<?xml version="1.0"?>'
+            '<!DOCTYPE doc ['
+            '<!ENTITY a "AAAAAAAAAA">'
+            '<!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">'
+            ']><doc>&b;</doc>'
+        )
+        with self.assertRaises(EntitiesForbidden):
+            redact_agreement_xml(bomb, focus_section_uuid=None, neighbor_sections=0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Bundles four MEDIUM-tier items from the original 40-item audit (Tier A — cheap, real risk reduction).

- **M12** — Add `_auth_enumeration_delay()` on the two login branches that previously revealed account existence without timing equalization: the local fast-path that fires when a verified user has a Zitadel link, and the re-raise of \"Verify your email before signing in.\" The slow-path wrong-credentials delay was already in place from PR #65.
- **M13** — New `require_turnstile_configured()` called from `/v1/auth/signup/password` and `/v1/auth/password-reset/request`. On Fly with `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` unset, the endpoint now returns 503 instead of silently dropping the captcha gate. Explicit `TURNSTILE_ENABLED=0` still opts out for ops convenience.
- **M18** — Gate `/swagger-ui` behind `EXPOSE_SWAGGER_UI` (default on locally, off on Fly). Removes a free-recon surface and the unlisted `cdn.jsdelivr.net` script origin in production. OpenAPI JSON spec is unchanged.
- **M20** — Parse agreement XML with `defusedxml` so billion-laughs / quadratic-blowup attacks are refused. Today's input is trusted (own DB); this is hardening for any future code path that routes user XML through `redaction.py`.

## Tests

- `backend/tests/test_auth.py`: 4 new tests — pending-block path invokes delay, signup + reset fail-closed on Fly with unset keys, explicit-disable still works on Fly.
- `backend/tests/test_redaction.py`: billion-laughs entity expansion rejected by `defusedxml`.
- `backend/tests/test_openapi_config.py` (new): 4 tests covering the swagger-UI gate truth table.
- Full backend suite: **277 tests passing**, basedpyright clean on all touched files.

## Test plan
- [x] Backend unit tests pass
- [x] basedpyright clean on touched files
- [ ] CI checks green
- [ ] Quick manual smoke: `/v1/auth/login/password` with wrong creds still works; `/swagger-ui` 404 on Fly preview (deferred — verify post-merge)