### PR TITLE
Security medium tier B: webhook startup check, Fly-Client-IP strict, signup log hash, flag length cap

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -147,6 +147,7 @@ from backend.auth.captcha_runtime import (
     verify_turnstile_token as _verify_turnstile_token,
 )
 from backend.auth.email_runtime import (
+    assert_zitadel_notification_signing_key_configured as _assert_zitadel_notification_signing_key_configured,
     frontend_base_url as _frontend_base_url,
     is_email_like as _is_email_like,
     normalize_email as _normalize_email,
@@ -1491,6 +1492,7 @@ def _register_app(target_app: Flask) -> None:
 def create_app(*, config_overrides: dict[str, object] | None = None) -> Flask:
     target_app = Flask(__name__)
     _configure_app(target_app, config_overrides=config_overrides)
+    _assert_zitadel_notification_signing_key_configured()
     _register_app(target_app)
     _ensure_auth_tables_exist(target_app)
     return target_app

--- a/backend/auth/email_runtime.py
+++ b/backend/auth/email_runtime.py
@@ -91,6 +91,23 @@ def zitadel_notification_signing_key() -> str | None:
     return key or None
 
 
+def assert_zitadel_notification_signing_key_configured() -> None:
+    # On Fly (production) we must have the signing key — otherwise
+    # verify_zitadel_signature() rejects every incoming notification and
+    # email delivery silently breaks. Fail fast at startup instead of
+    # discovering this via user reports.
+    from backend.auth.session_runtime import is_running_on_fly
+
+    if not is_running_on_fly():
+        return
+    if zitadel_notification_signing_key() is None:
+        raise RuntimeError(
+            "AUTH_ZITADEL_NOTIFICATION_SIGNING_KEY is required on Fly: "
+            "without it ZITADEL email notifications are rejected and "
+            "verification / password-reset mails stop being delivered."
+        )
+
+
 def verify_zitadel_signature(*, raw_body: bytes, signature_header: str | None) -> bool:
     signing_key = zitadel_notification_signing_key()
     if signing_key is None:

--- a/backend/core/runtime_utils.py
+++ b/backend/core/runtime_utils.py
@@ -215,14 +215,15 @@ def utc_datetime_from_ms(value: object, *, field: str) -> datetime:
 
 def request_ip_address(*, is_running_on_fly: bool) -> str | None:
     if is_running_on_fly:
+        # Fly's edge proxy always sets Fly-Client-IP. We deliberately do NOT
+        # fall back to X-Forwarded-For here — XFF's first hop is client-
+        # injectable if the edge ever fails to strip it, which would let an
+        # attacker spoof the IP for rate-limiting / audit fields. If
+        # Fly-Client-IP is missing the request is treated as IP-unknown.
         fly_client_ip = request.headers.get("Fly-Client-IP")
         if isinstance(fly_client_ip, str) and fly_client_ip.strip():
             return fly_client_ip.strip()
-
-        forwarded_for = request.headers.get("X-Forwarded-For")
-        if isinstance(forwarded_for, str) and forwarded_for.strip():
-            first = forwarded_for.split(",", 1)[0].strip()
-            return first or None
+        return None
     remote = request.remote_addr
     return remote.strip() if isinstance(remote, str) and remote.strip() else None
 

--- a/backend/routes/auth/__init__.py
+++ b/backend/routes/auth/__init__.py
@@ -2592,8 +2592,13 @@ window.location.replace({json.dumps(login_url)});
             # response is shape-indistinguishable from a legitimate new signup.
             # The real user will be told to check their email; if no message
             # arrives, they can sign in or use the password-reset flow.
+            # Log the hashed email rather than the raw address — the log
+            # line is the enumeration signal the response is supposed to
+            # mask, so anyone with log access shouldn't be able to read
+            # which addresses already had accounts.
             current_app.logger.info(
-                "signup_password_existing_account_masked email=%s", email
+                "signup_password_existing_account_masked email_sha256=%s",
+                sha256(email.encode("utf-8")).hexdigest()[:16],
             )
             resp = make_response(
                 jsonify(

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -1,6 +1,6 @@
 """Marshmallow schemas for auth request/response validation."""
 
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, validate
 
 
 class AuthApiKeySchema(Schema):
@@ -46,6 +46,8 @@ class AuthFlagInaccurateSchema(Schema):
     source = fields.Str(required=True)
     agreement_uuid = fields.Str(required=True)
     section_uuid = fields.Str(required=False, allow_none=True)
-    message = fields.Str(required=False, allow_none=True)
+    message = fields.Str(
+        required=False, allow_none=True, validate=validate.Length(max=2000)
+    )
     request_follow_up = fields.Bool(required=False, allow_none=True)
     issue_types = fields.List(fields.Str(), required=True)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -4511,6 +4511,74 @@ class AuthFlowTests(unittest.TestCase):
 
         self.assertEqual(res.status_code, 503)
 
+    def test_signup_existing_account_log_does_not_leak_raw_email(self):
+        # The endpoint masks existing-vs-new in its response shape; the log
+        # line must not leak the answer back to whoever has log access.
+        os.environ["AUTH_SESSION_TRANSPORT"] = "bearer"
+        existing_email = "log-leak@example.com"
+        with self.app.app_context():
+            user_id = self._create_local_user(
+                email=existing_email, verified=True, legal=True
+            )
+            db.session.add(
+                self._auth_external_subject(
+                    user_id=user_id,
+                    issuer="https://pandects-test-zitadel.example.com",
+                    subject="zitadel-log-leak-user",
+                )
+            )
+            db.session.commit()
+        client = self.app.test_client()
+
+        import logging
+        from io import StringIO
+
+        buffer = StringIO()
+        handler = logging.StreamHandler(buffer)
+        handler.setLevel(logging.INFO)
+        self.app.logger.addHandler(handler)
+        previous_level = self.app.logger.level
+        self.app.logger.setLevel(logging.INFO)
+        try:
+            res = client.post(
+                "/v1/auth/signup/password",
+                json={
+                    "email": existing_email,
+                    "password": "Secr3tP4ss!",
+                    "next": "/account",
+                },
+            )
+        finally:
+            self.app.logger.removeHandler(handler)
+            self.app.logger.setLevel(previous_level)
+
+        self.assertEqual(res.status_code, 200)
+        log_output = buffer.getvalue()
+        self.assertIn("signup_password_existing_account_masked", log_output)
+        self.assertNotIn(existing_email, log_output)
+        self.assertIn("email_sha256=", log_output)
+
+    def test_flag_inaccurate_rejects_overlong_message(self):
+        os.environ["AUTH_SESSION_TRANSPORT"] = "bearer"
+        self._create_local_user(email="flag-len@example.com")
+        client = self.app.test_client()
+        headers = {
+            "Authorization": f"Bearer {self._issue_bearer_session(email='flag-len@example.com')}"
+        }
+        res = client.post(
+            "/v1/auth/flag-inaccurate",
+            headers=headers,
+            json={
+                "source": "search_result",
+                "agreement_uuid": "a1",
+                "section_uuid": "s1",
+                "message": "x" * 2001,
+                "request_follow_up": False,
+                "issue_types": ["Incorrect metadata"],
+            },
+        )
+        self.assertIn(res.status_code, (400, 422))
+
     def test_password_reset_request_allowed_when_turnstile_explicitly_disabled(self):
         # Explicit opt-out (TURNSTILE_ENABLED=0) must keep working even on Fly
         # so the operator can disable captcha for a specific deployment.

--- a/backend/tests/test_route_contracts.py
+++ b/backend/tests/test_route_contracts.py
@@ -2,8 +2,6 @@ import os
 import tempfile
 import unittest
 
-from backend.app import api, create_test_app, db
-
 
 def _set_default_env() -> None:
     os.environ.setdefault("SKIP_MAIN_DB_REFLECTION", "1")
@@ -19,6 +17,8 @@ def _set_default_env() -> None:
     os.environ.setdefault("AUTH_SESSION_TRANSPORT", "bearer")
 
 
+# Env must be set before importing backend.app — module load triggers
+# create_app(), which otherwise tries to connect to a real Postgres host.
 _set_default_env()
 _AUTH_DB_TEMP = tempfile.NamedTemporaryFile(
     prefix="pandects_auth_routes_",
@@ -27,6 +27,8 @@ _AUTH_DB_TEMP = tempfile.NamedTemporaryFile(
 )
 _AUTH_DB_TEMP.close()
 os.environ.setdefault("AUTH_DATABASE_URI", f"sqlite:///{_AUTH_DB_TEMP.name}")
+
+from backend.app import api, create_test_app, db  # noqa: E402
 
 
 class RouteContractTests(unittest.TestCase):

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -1,0 +1,103 @@
+import os
+import unittest
+
+from flask import Flask
+
+
+class AssertZitadelNotificationSigningKeyTests(unittest.TestCase):
+    """Fail-fast startup check: on Fly the notification signing key must be
+    configured or every webhook is rejected and email delivery silently
+    breaks. Outside Fly the check is a no-op so local dev / tests don't need
+    to set the env var."""
+
+    _saved_fly: str | None = None
+    _saved_region: str | None = None
+    _saved_key: str | None = None
+
+    def setUp(self) -> None:
+        self._saved_fly = os.environ.pop("FLY_APP_NAME", None)
+        self._saved_region = os.environ.pop("FLY_REGION", None)
+        self._saved_key = os.environ.pop("AUTH_ZITADEL_NOTIFICATION_SIGNING_KEY", None)
+
+    def tearDown(self) -> None:
+        for k in ("FLY_APP_NAME", "FLY_REGION", "AUTH_ZITADEL_NOTIFICATION_SIGNING_KEY"):
+            os.environ.pop(k, None)
+        if self._saved_fly is not None:
+            os.environ["FLY_APP_NAME"] = self._saved_fly
+        if self._saved_region is not None:
+            os.environ["FLY_REGION"] = self._saved_region
+        if self._saved_key is not None:
+            os.environ["AUTH_ZITADEL_NOTIFICATION_SIGNING_KEY"] = self._saved_key
+
+    def test_off_fly_no_key_is_fine(self) -> None:
+        from backend.auth.email_runtime import (
+            assert_zitadel_notification_signing_key_configured,
+        )
+
+        assert_zitadel_notification_signing_key_configured()
+
+    def test_on_fly_missing_key_raises(self) -> None:
+        os.environ["FLY_APP_NAME"] = "pandects-test"
+        from backend.auth.email_runtime import (
+            assert_zitadel_notification_signing_key_configured,
+        )
+
+        with self.assertRaises(RuntimeError) as ctx:
+            assert_zitadel_notification_signing_key_configured()
+        self.assertIn("AUTH_ZITADEL_NOTIFICATION_SIGNING_KEY", str(ctx.exception))
+
+    def test_on_fly_with_key_is_fine(self) -> None:
+        os.environ["FLY_APP_NAME"] = "pandects-test"
+        os.environ["AUTH_ZITADEL_NOTIFICATION_SIGNING_KEY"] = "test-key"
+        from backend.auth.email_runtime import (
+            assert_zitadel_notification_signing_key_configured,
+        )
+
+        assert_zitadel_notification_signing_key_configured()
+
+
+class RequestIpAddressOnFlyTests(unittest.TestCase):
+    """On Fly the edge always sets Fly-Client-IP. We deliberately do NOT
+    fall back to X-Forwarded-For, since XFF's first hop is client-injectable
+    if the edge ever fails to strip it."""
+
+    def setUp(self) -> None:
+        self.app = Flask(__name__)
+
+    def test_fly_returns_fly_client_ip(self) -> None:
+        from backend.core.runtime_utils import request_ip_address
+
+        with self.app.test_request_context(
+            "/",
+            headers={
+                "Fly-Client-IP": "203.0.113.5",
+                "X-Forwarded-For": "10.0.0.1",
+            },
+        ):
+            self.assertEqual(request_ip_address(is_running_on_fly=True), "203.0.113.5")
+
+    def test_fly_without_fly_client_ip_returns_none_even_if_xff_present(self) -> None:
+        # Spoof-defense: a malicious client setting XFF must not be trusted
+        # as a source IP for rate-limiting / audit fields when Fly's edge
+        # didn't tag the request.
+        from backend.core.runtime_utils import request_ip_address
+
+        with self.app.test_request_context(
+            "/",
+            headers={"X-Forwarded-For": "198.51.100.9"},
+            environ_base={"REMOTE_ADDR": "10.0.0.2"},
+        ):
+            self.assertIsNone(request_ip_address(is_running_on_fly=True))
+
+    def test_off_fly_uses_remote_addr(self) -> None:
+        from backend.core.runtime_utils import request_ip_address
+
+        with self.app.test_request_context(
+            "/",
+            environ_base={"REMOTE_ADDR": "127.0.0.1"},
+        ):
+            self.assertEqual(request_ip_address(is_running_on_fly=False), "127.0.0.1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Bundles four MEDIUM-tier items from the original 40-item audit (Tier B — small code changes, real risk reduction).

- **M9** — `assert_zitadel_notification_signing_key_configured()` called from `create_app()`. On Fly without `AUTH_ZITADEL_NOTIFICATION_SIGNING_KEY`, fail fast at startup instead of silently rejecting every webhook (which today silently breaks verification + password-reset email delivery).
- **M11** — Drop the X-Forwarded-For fallback in `request_ip_address()` when on Fly. Fly's edge always sets Fly-Client-IP; XFF's first hop is client-injectable if the edge ever fails to strip it. Without this an attacker could spoof the IP used for rate limits and audit fields on `AuthSession`. Callers already tolerate None.
- **M14** — Log the SHA-256 of the email (16 hex chars) instead of the raw address on the masked-existing-account branch of `/signup/password`. The response was carefully masked to avoid enumeration; the log was undoing that mask.
- **M21** — `validate.Length(max=2000)` on `AuthFlagInaccurateSchema.message`. Prevents the admin inbox from being flooded with arbitrarily-long user-controlled bodies via `/v1/auth/flag-inaccurate`.

## Tests

- New `backend/tests/test_security_hardening.py`: 6 tests — webhook signing-key check truth table (3) and IP-resolution cases including the spoofing-defense (3).
- `backend/tests/test_auth.py`: 2 new tests — raw email absent from signup log, overlong flag-inaccurate message rejected.
- Full backend suite: **285 tests passing**, basedpyright (CI config) clean.

## Test plan
- [x] Backend unit tests pass
- [x] basedpyright clean (CI pyrightconfig.json)
- [ ] CI checks green