### PR TITLE
Clean up basedpyright errors in test files

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -3948,6 +3948,7 @@ class AuthFlowTests(unittest.TestCase):
         # Fresh client: last_used_at is NULL until somebody actually authorizes.
         with self.app.app_context():
             row = AuthOAuthClient.query.filter_by(client_id=client_id).first()
+            assert row is not None
             self.assertIsNone(row.last_used_at)
 
         self._grant_oauth_consent(
@@ -3971,6 +3972,7 @@ class AuthFlowTests(unittest.TestCase):
 
         with self.app.app_context():
             row = AuthOAuthClient.query.filter_by(client_id=client_id).first()
+            assert row is not None
             self.assertIsNotNone(row.last_used_at)
             after_authorize = row.last_used_at
 
@@ -3989,6 +3991,7 @@ class AuthFlowTests(unittest.TestCase):
 
         with self.app.app_context():
             row = AuthOAuthClient.query.filter_by(client_id=client_id).first()
+            assert row is not None
             self.assertIsNotNone(row.last_used_at)
             self.assertGreaterEqual(row.last_used_at, after_authorize)
 

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -61,6 +61,8 @@ class RequestIpAddressOnFlyTests(unittest.TestCase):
     fall back to X-Forwarded-For, since XFF's first hop is client-injectable
     if the edge ever fails to strip it."""
 
+    app: Flask = Flask(__name__)
+
     def setUp(self) -> None:
         self.app = Flask(__name__)
 


### PR DESCRIPTION
## Summary

Removes the last 5 basedpyright errors from \`backend/tests/test_auth.py\` (\`last_used_at\` access on a potentially-None query result) and 1 from \`backend/tests/test_security_hardening.py\` (uninitialized class attribute). All were latent — the CI \`pyrightconfig.json\` suppresses these rules in tests, but a top-level strict run surfaced them.

Pure test cleanup, no runtime change.

## Test plan
- [x] basedpyright strict (no project config): 0 errors
- [x] basedpyright CI config: 0 errors
- [x] Full backend suite: 287/287 passing