### PR TITLE
Tech-debt auto-fixes: CI concurrency, test isolation, useMemo cleanup

### DIFF
--- a/.github/workflows/backend-quality.yml
+++ b/.github/workflows/backend-quality.yml
@@ -1,5 +1,11 @@
 name: Backend Quality
 
+# Cancel superseded runs on the same ref (force-pushes, rapid commits)
+# so we don't burn CI minutes on stale workflows.
+concurrency:
+  group: backend-quality-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/oss-quality.yml
+++ b/.github/workflows/oss-quality.yml
@@ -1,5 +1,9 @@
 name: OSS Quality
 
+concurrency:
+  group: oss-quality-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/backend/tests/test_main_routes.py
+++ b/backend/tests/test_main_routes.py
@@ -392,8 +392,14 @@ class MainRoutesTests(unittest.TestCase):
                 )
 
     def setUp(self) -> None:
+        # Reset every shared mutable state on backend.app that a request
+        # path could touch — otherwise a test that exercises the login
+        # throttle or API-key last-used touch leaves residue for the next
+        # test and produces order-dependent failures.
         self.app_module._rate_limit_state.clear()
         self.app_module._endpoint_rate_limit_state.clear()
+        self.app_module._account_login_failure_state.clear()
+        self.app_module._api_key_last_used_touch_state.clear()
         self._restore_base_dataset()
 
     def _restore_base_dataset(self) -> None:

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -598,6 +598,13 @@ class McpTests(unittest.TestCase):
 
     def setUp(self) -> None:
         get_mcp_metrics_registry().reset()
+        # MCP routes share the same rate-limit / login-throttle dicts as
+        # the rest of the Flask app. Clear them so a previous test's
+        # state can't make this one flap on the rate-limiter.
+        self.app_module._rate_limit_state.clear()
+        self.app_module._endpoint_rate_limit_state.clear()
+        self.app_module._account_login_failure_state.clear()
+        self.app_module._api_key_last_used_touch_state.clear()
 
     def _bearer(self, scope: str = "sections:search agreements:search agreements:read") -> str:
         return self._bearer_for_subject(subject="sub-123", scope=scope)

--- a/frontend/client/components/NavigationDesktopMenus.tsx
+++ b/frontend/client/components/NavigationDesktopMenus.tsx
@@ -12,6 +12,28 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
+// Pure constants — hoisted out of the component so the array identity is
+// stable across renders without needing useMemo(..., []).
+type AboutLink = { to: string; label: string; pandaTarget?: string };
+const ABOUT_LINKS: readonly AboutLink[] = [
+  { to: "/about", label: "About", pandaTarget: "nav-about" },
+  { to: "/feedback", label: "Feedback" },
+  { to: "/support", label: "Support", pandaTarget: "nav-support" },
+];
+
+const DATA_LINKS = [
+  { type: "link", to: "/bulk-data", label: "Bulk Data", pandaTarget: "nav-bulk-data" },
+  { type: "link", to: "/agreement-index", label: "Agreement Index" },
+  { type: "link", to: "/sources-methods", label: "Sources & Methods" },
+  { type: "link", to: "/xml-schema", label: "XML Schema" },
+  { type: "link", to: "/taxonomy", label: "Taxonomy" },
+  { type: "separator", key: "data-divider-1" },
+  { type: "link", to: "/leaderboards", label: "Leaderboards" },
+  { type: "link", to: "/trends-analyses", label: "Trends & Analyses" },
+] as const;
+
+const DATA_NAV_LINKS = DATA_LINKS.filter((item) => item.type === "link");
+
 const AuthMenu = lazy(() =>
   import("@/components/AuthMenu").then((mod) => ({ default: mod.AuthMenu })),
 );
@@ -43,30 +65,8 @@ function NavigationDesktopMenusComponent() {
     ],
     [docsHomeUrl],
   );
-  const aboutLinks = useMemo(
-    () => [
-      { to: "/about", label: "About", pandaTarget: "nav-about" },
-      { to: "/feedback", label: "Feedback" },
-      { to: "/support", label: "Support", pandaTarget: "nav-support" },
-    ],
-    [],
-  );
-  const dataLinks = useMemo(
-    () => [
-      { type: "link", to: "/bulk-data", label: "Bulk Data", pandaTarget: "nav-bulk-data" },
-      { type: "link", to: "/agreement-index", label: "Agreement Index" },
-      { type: "link", to: "/sources-methods", label: "Sources & Methods" },
-      { type: "link", to: "/xml-schema", label: "XML Schema" },
-      { type: "link", to: "/taxonomy", label: "Taxonomy" },
-      { type: "separator", key: "data-divider-1" },
-      { type: "link", to: "/leaderboards", label: "Leaderboards" },
-      { type: "link", to: "/trends-analyses", label: "Trends & Analyses" },
-    ] as const,
-    [],
-  );
-  const dataNavLinks = dataLinks.filter((item) => item.type === "link");
-  const isDataActive = dataNavLinks.some((link) => isActive(link.to));
-  const isAboutActive = aboutLinks.some((link) => isActive(link.to));
+  const isDataActive = DATA_NAV_LINKS.some((link) => isActive(link.to));
+  const isAboutActive = ABOUT_LINKS.some((link) => isActive(link.to));
 
   return (
     <div className="hidden items-center gap-1 md:flex">
@@ -135,7 +135,7 @@ function NavigationDesktopMenusComponent() {
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="w-56">
-            {dataLinks.map((item) =>
+            {DATA_LINKS.map((item) =>
               item.type === "separator" ? (
                 <DropdownMenuSeparator key={item.key} className={dataSeparatorClass} />
               ) : (
@@ -177,7 +177,7 @@ function NavigationDesktopMenusComponent() {
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="w-56">
-            {aboutLinks.map((link) => (
+            {ABOUT_LINKS.map((link) => (
               <DropdownMenuItem key={link.to} asChild>
                 <Link
                   to={link.to}


### PR DESCRIPTION
## Summary

Mechanical hygiene fixes from a cross-cutting tech-debt scan (backend, frontend, tests/tooling). All larger refactors are deferred to a punch list that I'll share separately — this PR only contains changes that don't need design judgment.

### Changes

- **CI concurrency** — \`backend-quality.yml\` and \`oss-quality.yml\` get \`concurrency\` groups with \`cancel-in-progress: true\`. Stops superseded runs on rapid pushes / force-pushes from burning CI minutes. Deliberately NOT applied to \`deploy-*.yml\` (canceling a deploy mid-flight is risky).
- **Test isolation** — \`test_main_routes.py\` and \`test_mcp.py\` setUp blocks only cleared a subset of the four shared mutable dicts on \`backend.app\` (\`_rate_limit_state\`, \`_endpoint_rate_limit_state\`, \`_account_login_failure_state\`, \`_api_key_last_used_touch_state\`). Routes those test files exercise can touch any of them, so a state leak could flap a future test. Now mirrors the full pattern from \`test_auth.py\`. Order-independence insurance; no behaviour change in the suite as it runs today.
- **NavigationDesktopMenus.tsx** — \`ABOUT_LINKS\` and \`DATA_LINKS\` were \`useMemo(..., [])\` over literal arrays (empty deps → memo never invalidates → hooks overhead bought nothing). Hoisted to module scope.

### Audit findings that turned out to be wrong / stale, not addressed:

- \`.nvmrc\` already exists with \`24\`.
- Vitest tests deliberately run in node env with \`vi.stubGlobal\` — adding \`vitest.config.ts\` with \`environment: jsdom\` would conflict.
- \`test_auth.py\` already resets env vars per-test via \`_set_default_env()\`; no leak.

## Test plan
- [x] Backend: 287/287 tests pass
- [x] Frontend: 82/82 vitest tests pass, \`npm run typecheck\` exits 0
- [ ] CI green