### PR TITLE
Fix search_sections output-contract crash; surface unrecognized standard_ids

### DIFF
--- a/backend/mcp/tools/__init__.py
+++ b/backend/mcp/tools/__init__.py
@@ -28,6 +28,7 @@ from backend.mcp.tools.dispatch import (
     McpToolSpec,
     _validate_output_against_schema,
 )
+from backend.mcp.tools.shared import _json_compatible_structure
 from backend.mcp.tools.handlers import (
     _get_agreement,
     _get_agreement_tax_clauses,
@@ -1015,10 +1016,11 @@ def call_tool(
         handler_kwargs["deps"] = agreements_deps
         handler_kwargs["reference_data_deps"] = reference_data_deps
     result = spec.handler(**handler_kwargs)
-    output_errors = _validate_output_against_schema(spec.output_schema, result.structured_content)
+    normalized_content = _json_compatible_structure(result.structured_content)
+    output_errors = _validate_output_against_schema(spec.output_schema, normalized_content)
     if output_errors:
         raise McpOutputValidationError(output_errors)
-    return result
+    return McpToolResult(text=result.text, structured_content=normalized_content)
 
 
 __all__ = ["McpOutputValidationError", "McpToolResult", "call_tool", "tool_definitions"]

--- a/backend/mcp/tools/handlers.py
+++ b/backend/mcp/tools/handlers.py
@@ -61,6 +61,42 @@ from backend.schemas.sections import SectionsArgsPayload, SectionsArgsSchema
 from backend.services.sections_service import run_sections
 
 
+def _partition_known_standard_ids(
+    agreements_deps: AgreementsDeps, standard_ids: list[str]
+) -> tuple[list[str], list[str]]:
+    """Split provided standard_ids into (recognized, unrecognized) order-preserving lists.
+
+    A standard_id is recognized only if it exists as a node in the L1/L2/L3 clause
+    taxonomy. Taxonomy expansion always echoes the raw input back, so membership must
+    be checked against the taxonomy tables directly to detect ids that silently match
+    nothing.
+    """
+    if not standard_ids:
+        return [], []
+    unique_ids = {value for value in standard_ids if value}
+    if not unique_ids:
+        return [], []
+    db = agreements_deps.db
+    known: set[str] = set()
+    for model in (agreements_deps.TaxonomyL1, agreements_deps.TaxonomyL2, agreements_deps.TaxonomyL3):
+        rows = cast(
+            list[tuple[object]],
+            db.session.query(cast(Any, model).standard_id)
+            .filter(cast(Any, model).standard_id.in_(unique_ids))
+            .all(),
+        )
+        known.update(value for (value,) in rows if isinstance(value, str))
+    recognized: list[str] = []
+    unrecognized: list[str] = []
+    seen: set[str] = set()
+    for sid in standard_ids:
+        if not sid or sid in seen:
+            continue
+        seen.add(sid)
+        (recognized if sid in known else unrecognized).append(sid)
+    return recognized, unrecognized
+
+
 def _list_agreements(
     deps: AgreementsDeps,
     *,
@@ -531,13 +567,29 @@ def _search_agreements(
         count_q = count_q.filter(section_exists)
 
     standard_ids = [v for v in cast(list[str], parsed_args["standard_id"]) if v]
+    standard_ids_expanded = False
+    taxonomy_filters: list[dict[str, str]] = []
+    unrecognized_standard_ids: list[str] = []
     if standard_ids:
+        _, unrecognized_standard_ids = _partition_known_standard_ids(deps, standard_ids)
         standard_ids_key = tuple(sorted(set(standard_ids)))
         expanded = list(deps._expand_taxonomy_standard_ids_cached(standard_ids_key))
+        standard_ids_expanded = set(expanded) != set(standard_ids_key)
         if expanded:
             std_id_clause = deps._standard_id_agreement_filter_expr(agreements.agreement_uuid, expanded)
             q = q.filter(std_id_clause)
             count_q = count_q.filter(std_id_clause)
+        seen_taxonomy: set[str] = set()
+        for sid in standard_ids:
+            if sid in seen_taxonomy:
+                continue
+            seen_taxonomy.add(sid)
+            taxonomy_filters.append(
+                {
+                    "standard_id": sid,
+                    "match_mode": "expanded_descendants" if standard_ids_expanded else "exact_node",
+                }
+            )
 
     if query:
         if query.isdigit():
@@ -585,6 +637,8 @@ def _search_agreements(
         "interpretation": _agreement_filter_interpretation(
             cast(AgreementsBulkArgsPayload, cast(object, parsed_args)),
             query=query,
+            taxonomy_filters=taxonomy_filters,
+            unrecognized_standard_ids=unrecognized_standard_ids,
         ),
         **meta,
     }
@@ -1267,6 +1321,22 @@ def _search_sections(
     if not include_xml:
         for item in results:
             item.pop("xml", None)
+
+    requested_standard_ids = [v for v in cast(list[str], parsed_args["standard_id"]) if v]
+    if requested_standard_ids:
+        _, unrecognized_standard_ids = _partition_known_standard_ids(
+            agreements_deps, requested_standard_ids
+        )
+        interpretation = response.get("interpretation")
+        if unrecognized_standard_ids and isinstance(interpretation, dict):
+            interpretation["unrecognized_standard_ids"] = unrecognized_standard_ids
+            notes = interpretation.get("notes")
+            if isinstance(notes, list):
+                notes.append(
+                    "Ignored unrecognized standard_id(s): "
+                    + ", ".join(unrecognized_standard_ids)
+                    + ". Use get_clause_taxonomy or suggest_clause_families to obtain valid taxonomy IDs."
+                )
 
     all_standard_ids: set[str] = set()
     for item in results:

--- a/backend/mcp/tools/output_schemas.py
+++ b/backend/mcp/tools/output_schemas.py
@@ -166,6 +166,7 @@ def _interpretation_schema() -> dict[str, object]:
         {
             "applied_filters": _array_of(_interpretation_filter_schema()),
             "taxonomy_filters": _array_of(_taxonomy_filter_schema()),
+            "unrecognized_standard_ids": _array_of({"type": "string"}),
             "heuristics_used": _array_of({"type": "string"}),
             "notes": _array_of({"type": "string"}),
         },

--- a/backend/mcp/tools/shared.py
+++ b/backend/mcp/tools/shared.py
@@ -35,6 +35,22 @@ def _json_compatible_value(value: object) -> object:
     return value
 
 
+def _json_compatible_structure(value: object) -> object:
+    """Recursively coerce a tool result into JSON-native types.
+
+    Handlers occasionally surface raw SQLAlchemy values (``date``/``Decimal``)
+    that are JSON-serializable only at the HTTP encoding layer. Output-schema
+    validation runs on the in-memory object, so normalize the whole structure
+    here to keep validation and serialization in agreement regardless of which
+    handler produced the payload.
+    """
+    if isinstance(value, dict):
+        return {str(key): _json_compatible_structure(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_compatible_structure(item) for item in value]
+    return _json_compatible_value(value)
+
+
 def _count_metadata_payload(
     *,
     mode: str,
@@ -54,18 +70,28 @@ def _interpretation_payload(
     *,
     applied_filters: list[dict[str, str]],
     taxonomy_filters: list[dict[str, str]] | None = None,
+    unrecognized_standard_ids: list[str] | None = None,
     heuristics_used: list[str] | None = None,
     notes: list[str] | None = None,
 ) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "applied_filters": applied_filters,
         "taxonomy_filters": taxonomy_filters or [],
         "heuristics_used": heuristics_used or [],
         "notes": notes or [],
     }
+    if unrecognized_standard_ids:
+        payload["unrecognized_standard_ids"] = unrecognized_standard_ids
+    return payload
 
 
-def _agreement_filter_interpretation(parsed_args: AgreementsBulkArgsPayload, *, query: str) -> dict[str, object]:
+def _agreement_filter_interpretation(
+    parsed_args: AgreementsBulkArgsPayload,
+    *,
+    query: str,
+    taxonomy_filters: list[dict[str, str]] | None = None,
+    unrecognized_standard_ids: list[str] | None = None,
+) -> dict[str, object]:
     applied_filters: list[dict[str, str]] = []
     for field_name in _STRUCTURED_FILTER_ARRAY_FIELDS:
         values = cast(list[object], parsed_args[field_name])
@@ -111,8 +137,18 @@ def _agreement_filter_interpretation(parsed_args: AgreementsBulkArgsPayload, *, 
         else:
             heuristics_used.append("prefix_name_match")
             notes.append("The free-text query uses prefix matching on target and acquirer names.")
+    if taxonomy_filters:
+        notes.append("Taxonomy filters reflect clause-family assignments and may act as proxies for broader legal concepts.")
+    if unrecognized_standard_ids:
+        notes.append(
+            "Ignored unrecognized standard_id(s): "
+            + ", ".join(unrecognized_standard_ids)
+            + ". Use get_clause_taxonomy or suggest_clause_families to obtain valid taxonomy IDs."
+        )
     return _interpretation_payload(
         applied_filters=applied_filters,
+        taxonomy_filters=taxonomy_filters,
+        unrecognized_standard_ids=unrecognized_standard_ids,
         heuristics_used=heuristics_used,
         notes=notes,
     )

--- a/backend/schemas/public_api.py
+++ b/backend/schemas/public_api.py
@@ -79,7 +79,10 @@ class AgreementsBulkArgsSchema(Schema):
     standard_id = fields.List(
         fields.Str(),
         load_default=[],
-        metadata={"description": "Filter to agreements that contain at least one section tagged with any of these taxonomy standard_ids. Accepts the same ids as search_sections."},
+        metadata={
+            "description": "Filter to agreements that contain at least one section tagged with any of these taxonomy standard_ids. Accepts the same ids as search_sections: opaque 16-character hex node IDs from get_clause_taxonomy or suggest_clause_families (not dotted numbers). Unrecognized IDs are ignored and reported under interpretation.unrecognized_standard_ids.",
+            "example": ["4207f2e8f6698935"],
+        },
     )
 
 

--- a/backend/schemas/sections.py
+++ b/backend/schemas/sections.py
@@ -106,9 +106,13 @@ class SectionsArgsSchema(Schema):
         metadata={
             "description": (
                 "Clause type taxonomy standard IDs (Clause Type in the Search UI). "
-                "Parent IDs expand to include descendant taxonomy nodes."
+                "These are opaque 16-character hex node IDs obtained from "
+                "get_clause_taxonomy or suggest_clause_families — not dotted numbers. "
+                "Parent IDs expand to include descendant taxonomy nodes. "
+                "Unrecognized IDs are ignored and reported under "
+                "interpretation.unrecognized_standard_ids."
             ),
-            "example": ["1.1", "1.2.3"],
+            "example": ["4207f2e8f6698935", "fe2f63338a1eaf30"],
         },
     )
     transaction_price_total = fields.List(fields.Str(), load_default=[])

--- a/backend/tests/fixtures/mcp_server_capabilities_snapshot.json
+++ b/backend/tests/fixtures/mcp_server_capabilities_snapshot.json
@@ -656,7 +656,10 @@
             "type": "string"
           },
           "standard_id": {
-            "description": "Filter to agreements that contain at least one section tagged with any of these taxonomy standard_ids. Accepts the same ids as search_sections.",
+            "description": "Filter to agreements that contain at least one section tagged with any of these taxonomy standard_ids. Accepts the same ids as search_sections: opaque 16-character hex node IDs from get_clause_taxonomy or suggest_clause_families (not dotted numbers). Unrecognized IDs are ignored and reported under interpretation.unrecognized_standard_ids.",
+            "example": [
+              "4207f2e8f6698935"
+            ],
             "items": {
               "type": "string"
             },
@@ -948,6 +951,12 @@
                     "match_mode"
                   ],
                   "type": "object"
+                },
+                "type": "array"
+              },
+              "unrecognized_standard_ids": {
+                "items": {
+                  "type": "string"
                 },
                 "type": "array"
               }
@@ -1301,10 +1310,10 @@
             "type": "string"
           },
           "standard_id": {
-            "description": "Clause type taxonomy standard IDs (Clause Type in the Search UI). Parent IDs expand to include descendant taxonomy nodes.",
+            "description": "Clause type taxonomy standard IDs (Clause Type in the Search UI). These are opaque 16-character hex node IDs obtained from get_clause_taxonomy or suggest_clause_families \u2014 not dotted numbers. Parent IDs expand to include descendant taxonomy nodes. Unrecognized IDs are ignored and reported under interpretation.unrecognized_standard_ids.",
             "example": [
-              "1.1",
-              "1.2.3"
+              "4207f2e8f6698935",
+              "fe2f63338a1eaf30"
             ],
             "items": {
               "type": "string"
@@ -1626,6 +1635,12 @@
                   "type": "object"
                 },
                 "type": "array"
+              },
+              "unrecognized_standard_ids": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
               }
             },
             "required": [
@@ -1912,7 +1927,10 @@
             ]
           },
           "standard_id": {
-            "description": "Filter to agreements that contain at least one section tagged with any of these taxonomy standard_ids. Accepts the same ids as search_sections.",
+            "description": "Filter to agreements that contain at least one section tagged with any of these taxonomy standard_ids. Accepts the same ids as search_sections: opaque 16-character hex node IDs from get_clause_taxonomy or suggest_clause_families (not dotted numbers). Unrecognized IDs are ignored and reported under interpretation.unrecognized_standard_ids.",
+            "example": [
+              "4207f2e8f6698935"
+            ],
             "items": {
               "type": "string"
             },

--- a/backend/tests/fixtures/mcp_tools_list_snapshot.json
+++ b/backend/tests/fixtures/mcp_tools_list_snapshot.json
@@ -173,7 +173,10 @@
           "type": "string"
         },
         "standard_id": {
-          "description": "Filter to agreements that contain at least one section tagged with any of these taxonomy standard_ids. Accepts the same ids as search_sections.",
+          "description": "Filter to agreements that contain at least one section tagged with any of these taxonomy standard_ids. Accepts the same ids as search_sections: opaque 16-character hex node IDs from get_clause_taxonomy or suggest_clause_families (not dotted numbers). Unrecognized IDs are ignored and reported under interpretation.unrecognized_standard_ids.",
+          "example": [
+            "4207f2e8f6698935"
+          ],
           "items": {
             "type": "string"
           },
@@ -465,6 +468,12 @@
                   "match_mode"
                 ],
                 "type": "object"
+              },
+              "type": "array"
+            },
+            "unrecognized_standard_ids": {
+              "items": {
+                "type": "string"
               },
               "type": "array"
             }
@@ -791,10 +800,10 @@
           "type": "string"
         },
         "standard_id": {
-          "description": "Clause type taxonomy standard IDs (Clause Type in the Search UI). Parent IDs expand to include descendant taxonomy nodes.",
+          "description": "Clause type taxonomy standard IDs (Clause Type in the Search UI). These are opaque 16-character hex node IDs obtained from get_clause_taxonomy or suggest_clause_families \u2014 not dotted numbers. Parent IDs expand to include descendant taxonomy nodes. Unrecognized IDs are ignored and reported under interpretation.unrecognized_standard_ids.",
           "example": [
-            "1.1",
-            "1.2.3"
+            "4207f2e8f6698935",
+            "fe2f63338a1eaf30"
           ],
           "items": {
             "type": "string"
@@ -1116,6 +1125,12 @@
                 "type": "object"
               },
               "type": "array"
+            },
+            "unrecognized_standard_ids": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "required": [
@@ -1376,7 +1391,10 @@
           ]
         },
         "standard_id": {
-          "description": "Filter to agreements that contain at least one section tagged with any of these taxonomy standard_ids. Accepts the same ids as search_sections.",
+          "description": "Filter to agreements that contain at least one section tagged with any of these taxonomy standard_ids. Accepts the same ids as search_sections: opaque 16-character hex node IDs from get_clause_taxonomy or suggest_clause_families (not dotted numbers). Unrecognized IDs are ignored and reported under interpretation.unrecognized_standard_ids.",
+          "example": [
+            "4207f2e8f6698935"
+          ],
           "items": {
             "type": "string"
           },

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -1134,6 +1134,84 @@ class McpTests(unittest.TestCase):
         self.assertEqual(contents[0]["uri"], "pandects://capabilities")
         self.assertIn("application/json", contents[0]["mimeType"])
 
+    def test_json_compatible_structure_normalizes_nested_temporal_and_decimal(self):
+        from backend.mcp.tools.shared import _json_compatible_structure
+
+        raw = {
+            "results": [
+                {
+                    "filing_date": date(2020, 1, 1),
+                    "price": Decimal("12.5"),
+                    "at": datetime(2020, 1, 1, 12, 0, 0),
+                }
+            ],
+            "nested": {"days": (date(2021, 6, 15),)},
+        }
+        normalized = cast(dict[str, object], _json_compatible_structure(raw))
+        results = cast(list[dict[str, object]], normalized["results"])
+        self.assertEqual(results[0]["filing_date"], "2020-01-01")
+        self.assertEqual(results[0]["price"], 12.5)
+        self.assertEqual(results[0]["at"], "2020-01-01T12:00:00")
+        nested = cast(dict[str, object], normalized["nested"])
+        self.assertEqual(cast(list[object], nested["days"])[0], "2021-06-15")
+
+    def test_section_result_with_raw_date_only_validates_after_normalization(self):
+        # Regression lock for the production search_sections crash: output-schema
+        # validation runs on the in-memory result, so a raw `date` (as MariaDB
+        # returns for filing_date) must be normalized before validation or every
+        # non-empty response violates the advertised contract.
+        from backend.mcp.tools.dispatch import _validate_output_against_schema
+        from backend.mcp.tools.output_schemas import _section_result_schema
+        from backend.mcp.tools.shared import _json_compatible_structure
+
+        schema = _section_result_schema()
+        raw_item: dict[str, object] = {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "section_uuid": "00000000-0000-0000-0000-000000000003",
+            "standard_id": ["2.1.1"],
+            "verified": False,
+            "filing_date": date(2020, 1, 1),
+            "transaction_price_total": Decimal("28399583416"),
+        }
+        self.assertTrue(_validate_output_against_schema(schema, raw_item))
+        normalized = _json_compatible_structure(raw_item)
+        self.assertEqual(_validate_output_against_schema(schema, normalized), {})
+
+    def test_search_sections_with_results_satisfies_output_contract(self):
+        res = self._call_tool("search_sections", {"standard_id": ["2.1.1"]})
+        self.assertEqual(res.status_code, 200)
+        body = res.get_json()
+        self.assertNotIn("error", body)
+        structured = body["result"]["structuredContent"]
+        self.assertGreater(len(structured["results"]), 0)
+        taxonomy_filters = structured["interpretation"]["taxonomy_filters"]
+        self.assertIn("2.1.1", [entry["standard_id"] for entry in taxonomy_filters])
+        self.assertNotIn("unrecognized_standard_ids", structured["interpretation"])
+
+    def test_search_sections_reports_unrecognized_standard_id(self):
+        res = self._call_tool("search_sections", {"standard_id": ["not-a-real-node"]})
+        self.assertEqual(res.status_code, 200)
+        interpretation = res.get_json()["result"]["structuredContent"]["interpretation"]
+        self.assertEqual(interpretation["unrecognized_standard_ids"], ["not-a-real-node"])
+        self.assertTrue(
+            any("unrecognized standard_id" in note for note in interpretation["notes"])
+        )
+
+    def test_search_agreements_echoes_taxonomy_filter_and_flags_unrecognized(self):
+        valid = self._call_tool("search_agreements", {"standard_id": ["2.1.1"]})
+        self.assertEqual(valid.status_code, 200)
+        valid_interp = valid.get_json()["result"]["structuredContent"]["interpretation"]
+        self.assertEqual(
+            [entry["standard_id"] for entry in valid_interp["taxonomy_filters"]],
+            ["2.1.1"],
+        )
+        self.assertNotIn("unrecognized_standard_ids", valid_interp)
+
+        bogus = self._call_tool("search_agreements", {"standard_id": ["bogus-id"]})
+        self.assertEqual(bogus.status_code, 200)
+        bogus_interp = bogus.get_json()["result"]["structuredContent"]["interpretation"]
+        self.assertEqual(bogus_interp["unrecognized_standard_ids"], ["bogus-id"])
+
     def test_tool_call_returns_jsonrpc_result_contract(self):
         client = self.app.test_client()
         with self.assertLogs("backend.mcp.routes", level="INFO") as log_context:

--- a/docs/docs/mcp/technical-details.md
+++ b/docs/docs/mcp/technical-details.md
@@ -115,6 +115,7 @@ The current MCP tools are:
 - `search_sections` is a clause-language retrieval surface, not a normalized document-facts surface
 - `search_sections` exposes `count_mode` and returns `count_metadata` plus `interpretation` so clients can tell when totals are exact versus estimated and when taxonomy is acting as a proxy
 - `search_agreements` returns exact totals today and also includes `count_metadata` plus `interpretation`
+- `standard_id` values are opaque 16-character hex node IDs obtained from `get_clause_taxonomy` or `suggest_clause_families` — they are not dotted decimal numbers. Unrecognized IDs are ignored (they silently match nothing) and are echoed back under `interpretation.unrecognized_standard_ids`, alongside `interpretation.taxonomy_filters`, so clients can detect a mistyped or stale ID rather than mistaking an empty result for "no matches"
 - `suggest_clause_families` exists to bridge plain-English concepts to taxonomy ids and now reports fit/confidence metadata so clients can distinguish canonical matches from broader proxies
 - `get_section_snippet` is a focused reading aid, not a replacement for `get_section` or a canonical extracted-facts surface
 - `get_section_snippets_batch` and `list_agreement_sections_batch` accept arrays of UUIDs and collapse multiple single-item calls into one round-trip; use them when a workflow would otherwise fan out across many agreements or sections


### PR DESCRIPTION
First of the audit-driven MCP fix PRs (findings #1 and #2).

## Problem
- **`search_sections` was broken in production**: it returned `-32603 "Tool result violated the advertised output contract"` on *every* non-empty result. Root cause: `call_tool` validated the **raw** handler payload against the output schema *before* JSON normalization, and `run_sections` emits `filing_date` as a `date` object (MariaDB `DATE`), which fails the `["string","null"]` check. The sibling `get_sections_batch`/`get_agreement` handlers happened to wrap values in `_json_compatible_value(...)`; `run_sections` did not. Empty results "passed" only because there were no rows to validate. The test suite never exercised a non-empty `search_sections`, so it shipped.
- **Silent `standard_id` false negatives**: the schema examples advertised dotted ids (`["1.1", "1.2.3"]`), but the live taxonomy uses opaque 16-char hex node ids (e.g. `4207f2e8f6698935`). Passing the documented example returned `0 results` — indistinguishable from a genuine no-match and from a garbage id. Neither `search_agreements` nor `search_sections` told the caller which filters were applied or ignored.

## Fix
- Normalize `result.structured_content` through a new recursive `_json_compatible_structure` in `call_tool` **before** output validation, so `date`/`datetime`/`Decimal` are coerced regardless of which handler produced them. This kills the whole class of "one handler forgot to serialize" bugs.
- Correct the `standard_id` examples/descriptions on `search_sections`, `search_agreements`, and `list_agreements` (opaque hex ids from `get_clause_taxonomy`/`suggest_clause_families`; not dotted).
- Echo applied `taxonomy_filters` and report ignored ids under `interpretation.unrecognized_standard_ids` (plus a note) for both search tools, so a mistyped/stale id is detectable. Unrecognized ids are detected by membership in the L1/L2/L3 taxonomy tables (expansion always echoes raw input, so it can't be used for this).

## Tests
- New: `search_sections` happy path validates with results; a section result carrying a raw `date`/`Decimal` only passes output validation *after* normalization (locks the regression); unrecognized ids surfaced for both `search_sections` and `search_agreements`; recognized id echoes `taxonomy_filters` with no `unrecognized_standard_ids`.
- Regenerated `mcp_tools_list_snapshot.json` and `mcp_server_capabilities_snapshot.json`.
- `backend.tests.test_mcp` (78), `test_runtime_typing_guards`, `test_route_contracts` all pass; `basedpyright` clean on touched files.
- Updated `docs/docs/mcp/technical-details.md` per the MCP-surface doc requirement.