### PR TITLE
Distinguish not-found from generic tool failure in MCP error contract

### DIFF
--- a/backend/mcp/routes/__init__.py
+++ b/backend/mcp/routes/__init__.py
@@ -21,7 +21,6 @@ from backend.auth.mcp_runtime import (
 from backend.mcp.routes.deps import McpDeps
 from backend.mcp.routes.helpers import (
     AUTHORIZATION_ERROR_MESSAGE,
-    BAD_TOOL_REQUEST_MESSAGE,
     INVALID_JSON_RPC_PAYLOAD_MESSAGE,
     PROTECTED_RESOURCE_UNAVAILABLE_MESSAGE,
     _apply_protocol_headers,
@@ -39,6 +38,7 @@ from backend.mcp.routes.helpers import (
     _resource_definitions,
     _sse_retry_probe_response,
     _stream_tool_call_response,
+    _tool_http_exception_response,
     metrics_registry,
 )
 from backend.mcp.tools import McpOutputValidationError, call_tool, tool_definitions
@@ -353,10 +353,12 @@ def register_mcp_routes(target_app: Flask, *, deps: McpDeps) -> Blueprint:
                     scope_count=len(principal.scopes),
                     error_category="http_exception",
                 )
+                error_code, error_message, error_data = _tool_http_exception_response(exc)
                 return _json_rpc_error(
                     request_id=request_id,
-                    code=-32602 if exc.code == 400 else -32004,
-                    message=BAD_TOOL_REQUEST_MESSAGE if exc.code == 400 else "Tool request failed.",
+                    code=error_code,
+                    message=error_message,
+                    data=error_data,
                 )
             latency_ms = max(0, int((time.perf_counter() - started_at) * 1000))
             if tool_name == "get_server_metrics" and isinstance(result.structured_content, dict):

--- a/backend/mcp/routes/helpers.py
+++ b/backend/mcp/routes/helpers.py
@@ -32,6 +32,31 @@ PROTECTED_RESOURCE_UNAVAILABLE_MESSAGE = "Protected resource metadata is unavail
 INVALID_JSON_RPC_PAYLOAD_MESSAGE = "Request body must be a JSON object."
 AUTHORIZATION_ERROR_MESSAGE = "You do not have permission to call this tool."
 BAD_TOOL_REQUEST_MESSAGE = "Tool request was invalid."
+NOT_FOUND_MESSAGE = (
+    "The requested resource was not found. Verify the identifier (e.g. UUID) with a "
+    "search or list tool before retrying; this is a bad-request condition, not a "
+    "transient server error."
+)
+# JSON-RPC application error code for a tool that ran but found no matching resource.
+# Distinct from -32004 (a genuine tool failure) so callers can tell a fixable request
+# from a server-side fault. Stays clear of -32001/-32003 (auth) and -32602 (bad args).
+NOT_FOUND_ERROR_CODE = -32002
+
+
+def _tool_http_exception_response(
+    exc: HTTPException,
+) -> tuple[int, str, dict[str, object] | None]:
+    """Map a tool HTTPException to a (jsonrpc_code, message, data) triple.
+
+    Distinguishes invalid-argument (400) and not-found (404) so an agent can tell a
+    fixable request from a genuine server failure. Other statuses stay opaque. Used by
+    both the JSON and SSE dispatch paths to keep their error contracts identical.
+    """
+    if exc.code == 400:
+        return -32602, BAD_TOOL_REQUEST_MESSAGE, None
+    if exc.code == 404:
+        return NOT_FOUND_ERROR_CODE, NOT_FOUND_MESSAGE, {"category": "not_found", "status_code": 404}
+    return -32004, "Tool request failed.", None
 
 
 def _client_prefers_sse() -> bool:
@@ -296,14 +321,15 @@ def _stream_tool_call_response(
                 scope_count=scope_count,
                 error_category="http_exception",
             )
+            error_code, error_message, error_data = _tool_http_exception_response(exc)
+            error_payload: dict[str, object] = {"code": error_code, "message": error_message}
+            if error_data is not None:
+                error_payload["data"] = error_data
             yield _encode_sse_event(
                 {
                     "jsonrpc": "2.0",
                     "id": request_id,
-                    "error": {
-                        "code": -32602 if exc.code == 400 else -32004,
-                        "message": BAD_TOOL_REQUEST_MESSAGE if exc.code == 400 else "Tool request failed.",
-                    },
+                    "error": error_payload,
                 }
             )
             return

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -711,6 +711,41 @@ class McpTests(unittest.TestCase):
         body = res.get_json()
         self.assertEqual(body["error"]["message"], "Tool request was invalid.")
 
+    def test_tool_http_exception_response_maps_status_codes(self):
+        from werkzeug.exceptions import InternalServerError, NotFound
+
+        from backend.mcp.routes.helpers import _tool_http_exception_response
+
+        bad_request_code, _, bad_request_data = _tool_http_exception_response(BadRequest())
+        self.assertEqual(bad_request_code, -32602)
+        self.assertIsNone(bad_request_data)
+
+        not_found_code, not_found_message, not_found_data = _tool_http_exception_response(NotFound())
+        self.assertEqual(not_found_code, -32002)
+        self.assertIn("not found", not_found_message.lower())
+        self.assertEqual(not_found_data, {"category": "not_found", "status_code": 404})
+
+        failed_code, failed_message, failed_data = _tool_http_exception_response(InternalServerError())
+        self.assertEqual(failed_code, -32004)
+        self.assertEqual(failed_message, "Tool request failed.")
+        self.assertIsNone(failed_data)
+
+    def test_get_section_not_found_returns_distinct_error(self):
+        res = self._call_tool(
+            "get_section", {"section_uuid": "00000000-0000-0000-0000-000000000099"}
+        )
+        self.assertEqual(res.status_code, 200)
+        body = res.get_json()
+        self.assertEqual(body["error"]["code"], -32002)
+        self.assertIn("not found", body["error"]["message"].lower())
+        self.assertEqual(body["error"]["data"], {"category": "not_found", "status_code": 404})
+
+    def test_invalid_section_uuid_stays_invalid_arguments_not_not_found(self):
+        res = self._call_tool("get_section", {"section_uuid": "not-a-uuid"})
+        self.assertEqual(res.status_code, 200)
+        body = res.get_json()
+        self.assertEqual(body["error"]["code"], -32602)
+
     def test_mcp_requires_bearer_token(self):
         client = self.app.test_client()
         res = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "initialize"})

--- a/docs/docs/mcp/technical-details.md
+++ b/docs/docs/mcp/technical-details.md
@@ -136,6 +136,16 @@ The current MCP tools are:
 - Every response carries an `MCP-Protocol-Version` header echoing the negotiated protocol version.
 - Advertised server capabilities: `tools`, `resources` (listChanged=false, subscribe=false), `prompts` (listChanged=false), and `logging` (`logging/setLevel` is accepted as a no-op).
 
+### Tool error codes
+
+`tools/call` failures use distinct JSON-RPC error codes so a client can tell a fixable request from a server-side fault. The codes are identical across the JSON and SSE response paths:
+
+- `-32602` — invalid tool arguments (schema/validation failure or a malformed identifier)
+- `-32002` — the tool ran but the requested resource was not found (e.g. an unknown agreement or section UUID); the error `data` is `{"category": "not_found", "status_code": 404}`. Verify the identifier with a search or list tool and retry — this is not a transient error.
+- `-32003` — missing scope / authorization
+- `-32603` — the tool result violated its advertised output schema
+- `-32004` — a genuine tool failure (server-side)
+
 ### Progress notifications
 
 When a `tools/call` request includes `params._meta.progressToken` **and** the client advertises `Accept: text/event-stream`, the server returns a multi-event SSE stream:


### PR DESCRIPTION
Third audit-driven MCP fix PR (finding #6). (Finding #7 — filter echo on `search_agreements` — already landed in #78.)

## Problem
A `tools/call` that aborted 404 (unknown agreement/section UUID) surfaced to the client as `-32004 "Tool request failed."` — **indistinguishable from a genuine server fault**. An agent couldn't tell "your identifier is wrong, fix it" from "retry / the server broke," so it couldn't self-correct. The two dispatch paths (JSON in `routes/__init__.py`, SSE in `routes/helpers.py`) also duplicated the mapping inline.

## Fix
- Map 404 → distinct `-32002` with a clear, actionable message and `data={"category":"not_found","status_code":404}`.
- `400` stays `-32602` (invalid arguments); all other statuses stay `-32004` (genuine failure).
- The mapping lives in one helper `_tool_http_exception_response`, used by **both** the JSON and SSE paths so their error contracts stay byte-for-byte identical.

## Tests
- Unit test of the mapping helper across 400/404/500.
- Integration: `get_section` with a well-formed but nonexistent UUID returns `-32002` + the not-found `data`; a malformed UUID still returns `-32602` (not 404).
- Existing detail-hiding (400) and database-503 tests are unaffected.
- `backend.tests.test_mcp` (76), guardrails, `basedpyright` all clean. Documented the tool error codes in `technical-details.md`.

No tool schema/snapshot changes (dispatch-only). Independent of #78/#79 (branches from main).