### PR TITLE
Separate not_found from http_exception in MCP metrics

### DIFF
--- a/backend/mcp/routes/__init__.py
+++ b/backend/mcp/routes/__init__.py
@@ -38,6 +38,7 @@ from backend.mcp.routes.helpers import (
     _resource_definitions,
     _sse_retry_probe_response,
     _stream_tool_call_response,
+    _tool_http_exception_category,
     _tool_http_exception_response,
     metrics_registry,
 )
@@ -351,7 +352,7 @@ def register_mcp_routes(target_app: Flask, *, deps: McpDeps) -> Blueprint:
                     latency_ms=max(0, int((time.perf_counter() - started_at) * 1000)),
                     request_id=request_id,
                     scope_count=len(principal.scopes),
-                    error_category="http_exception",
+                    error_category=_tool_http_exception_category(exc),
                 )
                 error_code, error_message, error_data = _tool_http_exception_response(exc)
                 return _json_rpc_error(

--- a/backend/mcp/routes/helpers.py
+++ b/backend/mcp/routes/helpers.py
@@ -59,6 +59,20 @@ def _tool_http_exception_response(
     return -32004, "Tool request failed.", None
 
 
+def _tool_http_exception_category(exc: HTTPException) -> str:
+    """Metrics error category for a tool HTTPException.
+
+    A 404 is a client mistake (bad identifier), not a server fault, so it gets its own
+    bucket instead of being lumped under the generic ``http_exception`` category. Mirrors
+    the code mapping in ``_tool_http_exception_response``.
+    """
+    if exc.code == 400:
+        return "validation"
+    if exc.code == 404:
+        return "not_found"
+    return "http_exception"
+
+
 def _client_prefers_sse() -> bool:
     accept_header = request.headers.get("Accept", "") or ""
     if not accept_header:
@@ -319,7 +333,7 @@ def _stream_tool_call_response(
                 latency_ms=max(0, int((time.perf_counter() - started_at) * 1000)),
                 request_id=request_id,
                 scope_count=scope_count,
-                error_category="http_exception",
+                error_category=_tool_http_exception_category(exc),
             )
             error_code, error_message, error_data = _tool_http_exception_response(exc)
             error_payload: dict[str, object] = {"code": error_code, "message": error_message}

--- a/backend/mcp/tools/__init__.py
+++ b/backend/mcp/tools/__init__.py
@@ -535,7 +535,7 @@ def _tool_specs() -> tuple[McpToolSpec, ...]:
         ),
         McpToolSpec(
             name="get_server_metrics",
-            description="Operator-oriented MCP telemetry: per-tool call counts, latency buckets, error categories, and auth-failure counts since the server started. Not needed for research workflows.",
+            description="Operator-oriented MCP telemetry: per-tool call counts, latency buckets, error categories, and auth-failure counts since the server started. Counters are per-process, so in a multi-worker deployment each call reports only the worker that served it, not a server-wide total. Not needed for research workflows.",
             input_schema=_empty_schema(),
             output_schema=_metrics_output_schema(),
             examples=(

--- a/backend/tests/fixtures/mcp_tools_list_snapshot.json
+++ b/backend/tests/fixtures/mcp_tools_list_snapshot.json
@@ -3411,7 +3411,7 @@
   },
   {
     "name": "get_server_metrics",
-    "description": "Operator-oriented MCP telemetry: per-tool call counts, latency buckets, error categories, and auth-failure counts since the server started. Not needed for research workflows.",
+    "description": "Operator-oriented MCP telemetry: per-tool call counts, latency buckets, error categories, and auth-failure counts since the server started. Counters are per-process, so in a multi-worker deployment each call reports only the worker that served it, not a server-wide total. Not needed for research workflows.",
     "annotations": {
       "negativeGuidance": [],
       "pagination": "none",

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -730,6 +730,17 @@ class McpTests(unittest.TestCase):
         self.assertEqual(failed_message, "Tool request failed.")
         self.assertIsNone(failed_data)
 
+    def test_tool_http_exception_category_separates_not_found(self):
+        from werkzeug.exceptions import InternalServerError, NotFound
+
+        from backend.mcp.routes.helpers import _tool_http_exception_category
+
+        # A 404 is a client mistake (bad identifier), so it gets its own metrics bucket
+        # rather than being lumped under the generic http_exception category.
+        self.assertEqual(_tool_http_exception_category(BadRequest()), "validation")
+        self.assertEqual(_tool_http_exception_category(NotFound()), "not_found")
+        self.assertEqual(_tool_http_exception_category(InternalServerError()), "http_exception")
+
     def test_get_section_not_found_returns_distinct_error(self):
         res = self._call_tool(
             "get_section", {"section_uuid": "00000000-0000-0000-0000-000000000099"}

--- a/docs/docs/mcp/technical-details.md
+++ b/docs/docs/mcp/technical-details.md
@@ -148,6 +148,8 @@ The current MCP tools are:
 - `-32603` — the tool result violated its advertised output schema
 - `-32004` — a genuine tool failure (server-side)
 
+In `get_server_metrics`, a not-found tool result is counted under its own `not_found` error category (not the generic `http_exception`), since a bad identifier is a client mistake rather than a server fault. Note that metrics counters are per-process: in a multi-worker deployment each `get_server_metrics` call reports only the worker that served it, not a server-wide total.
+
 ### Progress notifications
 
 When a `tools/call` request includes `params._meta.progressToken` **and** the client advertises `Accept: text/event-stream`, the server returns a multi-event SSE stream:


### PR DESCRIPTION
## Summary
Closes the two minor metrics-telemetry nits surfaced in the post-deploy MCP re-audit.

- **`not_found` is its own metrics bucket.** `get_server_metrics` previously counted tool 404s under the generic `http_exception` error category, masking client-side bad-identifier mistakes as server faults. Added `_tool_http_exception_category` (mirrors the existing `_tool_http_exception_response` code mapping) so a 404 → `not_found` and a 400 → `validation`; wired into both the JSON and SSE dispatch paths.
- **Per-process caveat documented.** `get_server_metrics` counters are per-process, so in a multi-worker deployment each call reports only the worker that served it, not a server-wide total. Noted in the tool description and `technical-details.md`.

## Testing
- `backend.tests.test_mcp` — 86 pass (added `test_tool_http_exception_category_separates_not_found`; regenerated tools/list snapshot for the description change)
- `backend.tests.test_route_contracts`, `backend.tests.test_runtime_typing_guards` — pass
- `basedpyright` on touched files — 0 errors