### PR TITLE
Cache exact search counts; add agreement date filters; raise search rate limits

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -187,6 +187,9 @@ from backend.auth.session_runtime import (
     set_auth_cookies as _set_auth_cookies,
     set_csrf_cookie as _set_csrf_cookie,
 )
+from backend.search_counts import (
+    cached_exact_query_count as _search_counts_cached_exact_query_count,
+)
 from backend.services.async_tasks import AsyncTaskRunner
 from backend.services.sections_service import (
     estimated_latest_sections_search_table_rows as _svc_estimated_latest_sections_search_table_rows,
@@ -406,6 +409,17 @@ _api_key_last_used_touch_state: dict[str, float] = {}
 _SEARCH_EXPLAIN_ESTIMATE_ENABLED = (
     os.environ.get("SEARCH_EXPLAIN_ESTIMATE_ENABLED", "1").strip() != "0"
 )
+
+# ── Cached exact result counts for paginated search ───────────────────────
+# A search's match count depends only on its filter signature, so it is the
+# same on every page. Memoizing it per signature turns one COUNT-per-page into
+# one COUNT-per-search; values stay exact, just reused while fresh.
+_SEARCH_COUNT_CACHE_TTL_SECONDS = float(
+    os.environ.get("SEARCH_COUNT_CACHE_TTL_SECONDS", "120")
+)
+_SEARCH_COUNT_CACHE_MAX_KEYS = int(os.environ.get("SEARCH_COUNT_CACHE_MAX_KEYS", "10000"))
+_search_count_cache: dict[str, tuple[float, int]] = {}
+_search_count_cache_lock = Lock()
 
 
 def _usage_buffer() -> UsageBuffer | None:
@@ -669,6 +683,7 @@ def _build_sections_service_deps() -> SectionsServiceDeps:
         Sections=Sections,
         _SEARCH_EXPLAIN_ESTIMATE_ENABLED=_SEARCH_EXPLAIN_ESTIMATE_ENABLED,
         _to_int=_to_int,
+        _cached_exact_query_count=_cached_exact_query_count,
         _estimated_query_row_count=_estimated_query_row_count,
         _estimated_latest_sections_search_table_rows=_estimated_latest_sections_search_table_rows,
         _row_mapping_as_dict=_row_mapping_as_dict,
@@ -683,6 +698,43 @@ def _build_sections_service_deps() -> SectionsServiceDeps:
 
 def _estimated_query_row_count(query: object) -> int | None:
     return _svc_estimated_query_row_count(_build_sections_service_deps(), query)
+
+
+def _current_dump_version_token() -> str:
+    """Stable token for the active data dump, scoping cached counts to it.
+
+    Returns ``"none"`` outside a request context (e.g. direct unit calls) so the
+    cached-count helper stays usable without a live request.
+    """
+    try:
+        dump = getattr(g, "dump_version", None)
+    except RuntimeError:
+        return "none"
+    if isinstance(dump, dict):
+        hash_value = dump.get("hash")
+        if isinstance(hash_value, str) and hash_value:
+            return hash_value
+    return "none"
+
+
+def _cached_exact_query_count(query: object, *, cache_key: str | None) -> int:
+    """Exact COUNT(*) for a search query, memoized per filter signature + dump.
+
+    `cache_key=None` bypasses the cache for an authoritative fresh count.
+    """
+    namespaced_key = (
+        None if cache_key is None else f"{_current_dump_version_token()}|{cache_key}"
+    )
+    return _search_counts_cached_exact_query_count(
+        query=query,
+        cache_key=namespaced_key,
+        cache=_search_count_cache,
+        lock=_search_count_cache_lock,
+        ttl_seconds=_SEARCH_COUNT_CACHE_TTL_SECONDS,
+        max_keys=_SEARCH_COUNT_CACHE_MAX_KEYS,
+        to_int=_to_int,
+        now=time.time,
+    )
 
 
 def _estimated_latest_sections_search_table_rows() -> int | None:
@@ -935,6 +987,43 @@ def _rate_limit_key(ctx: AccessContext) -> tuple[str, int]:
     return f"anon:{ip}", 60
 
 
+# Read-only search endpoints are paginated, so a single user session legitimately
+# fans out into many GETs. Give those reads their own higher-ceiling bucket
+# (separate key prefix) so deep pagination is not throttled by — and does not
+# starve — the general per-tier limit shared by all other /v1 traffic.
+_SEARCH_READ_RATE_LIMIT_PATHS = frozenset(
+    {
+        "/v1/sections",
+        "/v1/search/agreements",
+        "/v1/tax-clauses",
+    }
+)
+_SEARCH_READ_RATE_LIMITS_BY_TIER = {
+    "anonymous": 300,
+    "user": 600,
+    "api_key": 1200,
+}
+
+
+def _is_search_read_request() -> bool:
+    if request.method != "GET":
+        return False
+    path = request.path
+    return (
+        path in _SEARCH_READ_RATE_LIMIT_PATHS
+        or path == "/v1/filter-options"
+        or path.startswith("/v1/filter-options/")
+    )
+
+
+def _apply_search_read_rate_limit(
+    ctx: AccessContext, key: str, per_minute: int
+) -> tuple[str, int]:
+    if not _is_search_read_request():
+        return key, per_minute
+    return f"search:{key}", _SEARCH_READ_RATE_LIMITS_BY_TIER.get(ctx.tier, per_minute)
+
+
 _ENDPOINT_RATE_LIMITS: dict[tuple[str, str], int] = {
     ("POST", "/v1/auth/flag-inaccurate"): 10,
     ("POST", "/v1/auth/signup/password"): 5,
@@ -1123,6 +1212,7 @@ def _check_rate_limit(ctx: AccessContext) -> None:
         return
 
     key, per_minute = _rate_limit_key(ctx)
+    key, per_minute = _apply_search_read_rate_limit(ctx, key, per_minute)
     now = time.time()
     window = _RATE_LIMIT_WINDOW_SECONDS
     with _rate_limit_lock:
@@ -1280,6 +1370,7 @@ def _build_tax_clauses_service_deps() -> TaxClausesServiceDeps:
         TaxClauseAssignment=TaxClauseAssignment,
         XML=XML,
         _to_int=_to_int,
+        _cached_exact_query_count=_cached_exact_query_count,
         _row_mapping_as_dict=_row_mapping_as_dict,
         _pagination_metadata=_pagination_metadata,
         _expand_tax_clause_taxonomy_standard_ids_cached=_expand_tax_clause_taxonomy_standard_ids_cached,
@@ -1335,6 +1426,7 @@ def _build_route_deps() -> tuple[SectionsDeps, AgreementsDeps, ReferenceDataDeps
         _section_latest_xml_join_condition=_section_latest_xml_join_condition,
         _standard_id_filter_expr=_standard_id_filter_expr,
         _standard_id_agreement_filter_expr=_standard_id_agreement_filter_expr,
+        _cached_exact_query_count=_cached_exact_query_count,
         _estimated_query_row_count=_estimated_query_row_count,
         _to_int=_to_int,
         _year_from_filing_date_value=_year_from_filing_date_value,

--- a/backend/routes/agreements/__init__.py
+++ b/backend/routes/agreements/__init__.py
@@ -28,6 +28,7 @@ from backend.routes.agreements.helpers import (
     _to_float_or_none,
 )
 from backend.routes.deps import AgreementsDeps
+from backend.search_counts import build_search_count_cache_key
 from backend.schemas.public_api import (
     AgreementArgsPayload,
     AgreementArgsSchema,
@@ -451,6 +452,7 @@ def register_agreements_routes(
             max_page_size = 100 if ctx.is_authenticated else 10
             if page_size < 1 or page_size > max_page_size:
                 page_size = min(25, max_page_size)
+            count_mode = parsed_args["count_mode"]
 
             clause_context_requested = bool(
                 parsed_args["standard_id"] or (
@@ -528,7 +530,16 @@ def register_agreements_routes(
                 )
                 has_next = len(page_rows_raw) > page_size
                 page_rows = page_rows_raw[:page_size]
-                total_count = deps._to_int(direct_query.order_by(None).count())
+                count_cache_key = (
+                    None
+                    if count_mode == "exact"
+                    else build_search_count_cache_key(
+                        "agreements_search:direct", parsed_args
+                    )
+                )
+                total_count = deps._cached_exact_query_count(
+                    direct_query, cache_key=count_cache_key
+                )
                 total_count_is_approximate = False
 
                 meta = deps._pagination_metadata(
@@ -628,7 +639,16 @@ def register_agreements_routes(
             )
             has_next = len(page_rows_raw) > page_size
             page_rows = page_rows_raw[:page_size]
-            total_count = deps._to_int(aggregated_query.order_by(None).count())
+            count_cache_key = (
+                None
+                if count_mode == "exact"
+                else build_search_count_cache_key(
+                    "agreements_search:clause", parsed_args
+                )
+            )
+            total_count = deps._cached_exact_query_count(
+                aggregated_query, cache_key=count_cache_key
+            )
             total_count_is_approximate = False
 
             meta = deps._pagination_metadata(

--- a/backend/routes/agreements/helpers.py
+++ b/backend/routes/agreements/helpers.py
@@ -107,6 +107,10 @@ def _build_agreement_search_match_query(
     acquirer_pes = parsed_args["acquirer_pe"]
     agreement_uuid = parsed_args["agreement_uuid"]
     section_uuid = parsed_args["section_uuid"]
+    year_min = parsed_args["year_min"]
+    year_max = parsed_args["year_max"]
+    filed_after = parsed_args["filed_after"]
+    filed_before = parsed_args["filed_before"]
 
     q = (
         db.session.query(
@@ -132,6 +136,15 @@ def _build_agreement_search_match_query(
             for year in years
         )
         q = q.filter(or_(*year_filters))
+
+    if year_min is not None:
+        q = q.filter(latest.filing_date >= f"{year_min:04d}-01-01")
+    if year_max is not None:
+        q = q.filter(latest.filing_date < f"{year_max + 1:04d}-01-01")
+    if filed_after:
+        q = q.filter(latest.filing_date >= filed_after)
+    if filed_before:
+        q = q.filter(latest.filing_date < filed_before)
 
     if targets:
         q = q.filter(latest.target.in_(targets))
@@ -281,6 +294,12 @@ def _apply_agreement_metadata_filters(
     acquirer_pes = parsed_args["acquirer_pe"]
     agreement_uuid = parsed_args["agreement_uuid"]
     section_uuid = parsed_args["section_uuid"]
+    # Date-range args are only present on the sections-shaped payload, not the
+    # bulk payload, so read them defensively.
+    year_min = parsed_args.get("year_min")
+    year_max = parsed_args.get("year_max")
+    filed_after = parsed_args.get("filed_after")
+    filed_before = parsed_args.get("filed_before")
 
     if years:
         year_filters = tuple(
@@ -291,6 +310,15 @@ def _apply_agreement_metadata_filters(
             for year in years
         )
         q = q.filter(or_(*year_filters))
+
+    if isinstance(year_min, int):
+        q = q.filter(agreements.filing_date >= f"{year_min:04d}-01-01")
+    if isinstance(year_max, int):
+        q = q.filter(agreements.filing_date < f"{year_max + 1:04d}-01-01")
+    if isinstance(filed_after, str) and filed_after:
+        q = q.filter(agreements.filing_date >= filed_after)
+    if isinstance(filed_before, str) and filed_before:
+        q = q.filter(agreements.filing_date < filed_before)
 
     if targets:
         q = q.filter(agreements.target.in_(targets))

--- a/backend/routes/deps.py
+++ b/backend/routes/deps.py
@@ -49,6 +49,10 @@ class ToIntProtocol(Protocol):
     def __call__(self, value: object, *, default: int = 0) -> int: ...
 
 
+class CachedExactQueryCountProtocol(Protocol):
+    def __call__(self, query: object, *, cache_key: str | None) -> int: ...
+
+
 class RowMappingAsDictProtocol(Protocol):
     def __call__(self, row: object) -> dict[str, object]: ...
 
@@ -175,6 +179,7 @@ class SectionsServiceDeps:
     Sections: Any
     _SEARCH_EXPLAIN_ESTIMATE_ENABLED: bool
     _to_int: ToIntProtocol
+    _cached_exact_query_count: CachedExactQueryCountProtocol
     _estimated_query_row_count: Callable[[object], int | None]
     _estimated_latest_sections_search_table_rows: Callable[[], int | None]
     _row_mapping_as_dict: RowMappingAsDictProtocol
@@ -228,6 +233,7 @@ class AgreementsDeps:
     _section_latest_xml_join_condition: Callable[[], object]
     _standard_id_filter_expr: Callable[[list[str]], object]
     _standard_id_agreement_filter_expr: Callable[[Any, list[str]], object]
+    _cached_exact_query_count: CachedExactQueryCountProtocol
     _estimated_query_row_count: Callable[[object], int | None]
     _to_int: ToIntProtocol
     _year_from_filing_date_value: Callable[[object], int | None]

--- a/backend/search_counts.py
+++ b/backend/search_counts.py
@@ -1,0 +1,119 @@
+"""Shared helpers for paginated-search result counts.
+
+The number of rows a search matches depends only on its filter signature, never
+on which page or sort order is being viewed. These helpers memoize the exact
+`COUNT(*)` per filter signature so paging through one search runs a single count
+instead of one per page, while every page reports the identical exact total.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any, Callable, Protocol, cast
+
+
+class ToIntProtocol(Protocol):
+    def __call__(self, value: object, *, default: int = 0) -> int: ...
+
+
+class _StatementQuery(Protocol):
+    def order_by(self, *clauses: object) -> "_StatementQuery": ...
+
+    def count(self) -> object: ...
+
+
+# Argument keys that never change which rows match a search. They must be kept
+# out of the cache key so that paging/sorting reuses one cached count. This is
+# an exclude-list on purpose: every other parsed arg participates in the key, so
+# a filter added later is captured automatically. Dropping a real filter from
+# the key is the only mistake that can return a wrong count; excluding a true
+# non-filter can at worst cost a redundant cache miss.
+_NON_FILTER_ARG_KEYS = frozenset(
+    {"page", "page_size", "sort_by", "sort_direction", "count_mode", "include_dump"}
+)
+
+
+def exact_query_count(query: object, to_int: ToIntProtocol) -> int:
+    """Run an exact `COUNT(*)` for a query, dropping any ORDER BY first."""
+    return to_int(cast(_StatementQuery, query).order_by(None).count())
+
+
+def build_search_count_cache_key(scope: str, parsed_args: Mapping[str, object]) -> str:
+    """Derive a stable cache key from a search's filter signature.
+
+    `scope` distinguishes endpoints (and query shapes within an endpoint). List
+    values are sorted because `IN (...)` filters are order-independent, which
+    lifts the cache hit rate without affecting which rows match.
+    """
+    filter_items: list[tuple[str, object]] = []
+    for key in sorted(parsed_args):
+        if key in _NON_FILTER_ARG_KEYS:
+            continue
+        value = parsed_args[key]
+        if isinstance(value, (list, tuple)):
+            value = sorted(str(item) for item in value)
+        filter_items.append((key, value))
+    raw = json.dumps([scope, filter_items], sort_keys=True, default=str)
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()
+
+
+def cached_exact_query_count(
+    *,
+    query: object,
+    cache_key: str | None,
+    cache: dict[str, tuple[float, int]],
+    lock: Any,
+    ttl_seconds: float,
+    max_keys: int,
+    to_int: ToIntProtocol,
+    now: Callable[[], float],
+) -> int:
+    """Exact `COUNT(*)` for `query`, memoized per `cache_key` for `ttl_seconds`.
+
+    `cache_key=None` bypasses the cache and always runs a fresh count (used when
+    a caller explicitly requests an authoritative, uncached total).
+    """
+    if cache_key is None:
+        return exact_query_count(query, to_int)
+
+    current = now()
+    with lock:
+        entry = cache.get(cache_key)
+        if entry is not None and (current - entry[0]) < ttl_seconds:
+            return entry[1]
+
+    # Run the COUNT outside the lock: it can hit the database and must not
+    # serialize unrelated count requests behind one slow query. A concurrent
+    # miss only costs a redundant COUNT, never a wrong value.
+    value = exact_query_count(query, to_int)
+
+    with lock:
+        _prune_count_cache(cache, max_keys, ttl_seconds, current)
+        cache[cache_key] = (current, value)
+    return value
+
+
+def _prune_count_cache(
+    cache: dict[str, tuple[float, int]],
+    max_keys: int,
+    ttl_seconds: float,
+    now_ts: float,
+) -> None:
+    expired = [key for key, (ts, _value) in cache.items() if (now_ts - ts) >= ttl_seconds]
+    for key in expired:
+        del cache[key]
+    overflow = len(cache) - max_keys
+    if overflow > 0:
+        oldest = sorted(cache.items(), key=lambda item: item[1][0])[:overflow]
+        for key, _entry in oldest:
+            del cache[key]
+
+
+__all__ = [
+    "ToIntProtocol",
+    "exact_query_count",
+    "build_search_count_cache_key",
+    "cached_exact_query_count",
+]

--- a/backend/services/sections_service.py
+++ b/backend/services/sections_service.py
@@ -10,6 +10,7 @@ from backend.filtering import (
     build_transaction_price_bucket_filter,
 )
 from backend.routes.deps import AccessContextProtocol, SectionsServiceDeps
+from backend.search_counts import build_search_count_cache_key
 from backend.schemas.sections import SectionsArgsPayload
 
 
@@ -105,22 +106,29 @@ def sections_total_count_metadata(
     has_next: bool,
     has_filters: bool,
     count_mode: str,
+    count_cache_key: str | None = None,
 ) -> tuple[int, bool, str]:
     """Return `(total_count, is_approximate, method)` without forcing exact counts unless requested.
 
     Filtered searches prefer conservative lower bounds once the user paginates past the
     first page. Unfiltered searches can fall back to the table-level estimate because the
     endpoint already reads from a denormalized latest-sections table.
+
+    Exact counts (explicit `count_mode=exact`, the filtered first page, and the
+    unfiltered fallback) are memoized per filter signature via `count_cache_key`
+    so paging one search re-counts once instead of once per page; the returned
+    value and `method` are unchanged. `count_cache_key=None` always counts fresh.
     """
     estimated_query_row_count_fn = deps._estimated_query_row_count
     estimated_table_rows_fn = deps._estimated_latest_sections_search_table_rows
     if count_mode == "exact":
-        exact_total = deps._to_int(cast(_StatementQuery, query).order_by(None).count())
+        # Explicit exactness request: always authoritative, never cached.
+        exact_total = deps._cached_exact_query_count(query, cache_key=None)
         return exact_total, False, "query_count"
 
     if has_filters:
         if page <= 1:
-            exact_total = deps._to_int(cast(_StatementQuery, query).order_by(None).count())
+            exact_total = deps._cached_exact_query_count(query, cache_key=count_cache_key)
             return exact_total, False, "query_count"
 
         exact_total = ((page - 1) * page_size) + item_count
@@ -137,7 +145,7 @@ def sections_total_count_metadata(
 
     table_rows = estimated_table_rows_fn()
     if table_rows is None:
-        table_rows = deps._to_int(cast(_StatementQuery, query).order_by(None).count())
+        table_rows = deps._cached_exact_query_count(query, cache_key=count_cache_key)
         total_count = max(item_count, table_rows)
         return total_count, False, "query_count"
     total_count = max(item_count, table_rows)
@@ -472,6 +480,11 @@ def run_sections(
             section_uuid and section_uuid.strip(),
         )
     )
+    count_cache_key = (
+        None
+        if count_mode == "exact"
+        else build_search_count_cache_key("sections", parsed_args)
+    )
     total_count, total_count_is_approximate, count_method = sections_total_count_metadata(
         deps,
         query=q,
@@ -481,6 +494,7 @@ def run_sections(
         has_next=has_next,
         has_filters=has_filters,
         count_mode=count_mode,
+        count_cache_key=count_cache_key,
     )
 
     section_uuids = [

--- a/backend/services/tax_clauses_service.py
+++ b/backend/services/tax_clauses_service.py
@@ -14,10 +14,12 @@ from backend.models.main_db import xml_latest_ok_filter
 from backend.routes.agreements import _agreement_is_public_eligible_expr
 from backend.routes.deps import (
     AccessContextProtocol,
+    CachedExactQueryCountProtocol,
     PaginationMetadataProtocol,
     RowMappingAsDictProtocol,
     ToIntProtocol,
 )
+from backend.search_counts import build_search_count_cache_key
 from backend.schemas.tax_clauses import TaxClausesArgsPayload
 
 
@@ -31,6 +33,7 @@ class TaxClausesServiceDeps:
     TaxClauseAssignment: Any
     XML: Any
     _to_int: ToIntProtocol
+    _cached_exact_query_count: CachedExactQueryCountProtocol
     _row_mapping_as_dict: RowMappingAsDictProtocol
     _pagination_metadata: PaginationMetadataProtocol
     _expand_tax_clause_taxonomy_standard_ids_cached: Callable[
@@ -245,7 +248,12 @@ def run_tax_clauses(
         if isinstance(value, str):
             clause_uuids.append(value)
 
-    total_count = deps._to_int(q.order_by(None).count())
+    count_cache_key = (
+        None
+        if count_mode == "exact"
+        else build_search_count_cache_key("tax_clauses", parsed_args)
+    )
+    total_count = deps._cached_exact_query_count(q, cache_key=count_cache_key)
     total_count_is_approximate = False
     count_method = "query_count"
 

--- a/backend/tests/test_main_routes.py
+++ b/backend/tests/test_main_routes.py
@@ -399,6 +399,7 @@ class MainRoutesTests(unittest.TestCase):
         self.app_module._rate_limit_state.clear()
         self.app_module._endpoint_rate_limit_state.clear()
         self.app_module._account_login_failure_state.clear()
+        self.app_module._search_count_cache.clear()
         self.app_module._api_key_last_used_touch_state.clear()
         self._restore_base_dataset()
 
@@ -1059,6 +1060,122 @@ class MainRoutesTests(unittest.TestCase):
         self.assertFalse(body.get("total_count_is_approximate"))
         self.assertEqual(body.get("total_count"), 10)
         self.assertEqual(body.get("total_pages"), 2)
+
+    def _seed_industry_agreements(self, *, industry: str, count: int, filing_dates=None):
+        with self.app.app_context():
+            engine = self.app_module.db.engine
+            with engine.begin() as conn:
+                for idx in range(count):
+                    uuid = f"{industry}-{idx:02d}"
+                    filing_date = (
+                        filing_dates[idx] if filing_dates is not None else "2020-01-01"
+                    )
+                    conn.execute(
+                        text(
+                            "INSERT INTO agreements (agreement_uuid, filing_date, target, "
+                            "acquirer, verified, url, target_industry) VALUES "
+                            "(:u, :filing_date, :t, :a, 1, :url, :industry)"
+                        ),
+                        {
+                            "u": uuid,
+                            "filing_date": filing_date,
+                            "t": f"Target {idx}",
+                            "a": f"Acquirer {idx}",
+                            "url": f"http://example.com/{uuid}",
+                            "industry": industry,
+                        },
+                    )
+                    conn.execute(
+                        text(
+                            "INSERT INTO xml (agreement_uuid, xml, version, status, latest) "
+                            "VALUES (:u, '<document><article><section uuid=\"s\">"
+                            "<text>Z</text></section></article></document>', 1, 'verified', 1)"
+                        ),
+                        {"u": uuid},
+                    )
+
+    def test_search_agreements_total_count_is_exact_and_stable_on_every_page(self):
+        # The agreements grid must show the true total on every page, never the
+        # "p to q of q+1" lower bound that past count rewrites regressed into.
+        self._seed_industry_agreements(industry="zcount", count=10)
+        client = self.app.test_client()
+
+        seen_totals: list[int | None] = []
+        for page in (1, 2, 3, 4):
+            res = client.get(
+                f"/v1/search/agreements?target_industry=zcount&page={page}&page_size=3"
+            )
+            self.assertEqual(res.status_code, 200)
+            body = res.get_json()
+            seen_totals.append(body.get("total_count"))
+            self.assertFalse(body.get("total_count_is_approximate"))
+
+        self.assertEqual(seen_totals, [10, 10, 10, 10])
+        # Page 2 (items 4-6, more to come) must not collapse to upper-bound + 1.
+        self.assertNotEqual(seen_totals[1], (2 - 1) * 3 + 3 + 1)
+
+    def test_search_agreements_count_is_cached_across_pages(self):
+        import backend.search_counts as search_counts
+
+        self._seed_industry_agreements(industry="zcache", count=6)
+        client = self.app.test_client()
+
+        original = search_counts.exact_query_count
+        with patch.object(
+            search_counts, "exact_query_count", side_effect=original
+        ) as spy:
+            first = client.get(
+                "/v1/search/agreements?target_industry=zcache&page=1&page_size=2"
+            )
+            second = client.get(
+                "/v1/search/agreements?target_industry=zcache&page=2&page_size=2"
+            )
+
+        self.assertEqual(first.get_json().get("total_count"), 6)
+        self.assertEqual(second.get_json().get("total_count"), 6)
+        # One COUNT for both pages: the second page reuses the cached total.
+        self.assertEqual(spy.call_count, 1)
+
+    def test_search_agreements_count_mode_exact_bypasses_cache(self):
+        import backend.search_counts as search_counts
+
+        self._seed_industry_agreements(industry="zexact", count=4)
+        client = self.app.test_client()
+
+        original = search_counts.exact_query_count
+        with patch.object(
+            search_counts, "exact_query_count", side_effect=original
+        ) as spy:
+            client.get(
+                "/v1/search/agreements"
+                "?target_industry=zexact&page=1&page_size=2&count_mode=exact"
+            )
+            client.get(
+                "/v1/search/agreements"
+                "?target_industry=zexact&page=2&page_size=2&count_mode=exact"
+            )
+
+        # count_mode=exact is authoritative: it never serves a cached total.
+        self.assertEqual(spy.call_count, 2)
+
+    def test_search_agreements_date_range_filters(self):
+        self._seed_industry_agreements(
+            industry="zdate",
+            count=3,
+            filing_dates=["2010-01-01", "2011-01-01", "2012-01-01"],
+        )
+        client = self.app.test_client()
+
+        def total(query: str) -> int:
+            res = client.get(f"/v1/search/agreements?target_industry=zdate&{query}")
+            self.assertEqual(res.status_code, 200)
+            return res.get_json().get("total_count")
+
+        self.assertEqual(total("year_min=2011"), 2)
+        self.assertEqual(total("year_max=2010"), 1)
+        self.assertEqual(total("filed_after=2011-06-01"), 1)
+        self.assertEqual(total("filed_before=2011-06-01"), 2)
+        self.assertEqual(total("year_min=2011&year_max=2011"), 1)
 
     def test_search_total_count_metadata_uses_table_estimate_for_unfiltered_search(self):
         with (

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -605,6 +605,7 @@ class McpTests(unittest.TestCase):
         self.app_module._endpoint_rate_limit_state.clear()
         self.app_module._account_login_failure_state.clear()
         self.app_module._api_key_last_used_touch_state.clear()
+        self.app_module._search_count_cache.clear()
 
     def _bearer(self, scope: str = "sections:search agreements:search agreements:read") -> str:
         return self._bearer_for_subject(subject="sub-123", scope=scope)

--- a/backend/tests/test_pagination_and_access.py
+++ b/backend/tests/test_pagination_and_access.py
@@ -57,6 +57,48 @@ class PaginationAndAccessTests(unittest.TestCase):
         self.assertFalse(meta["has_next"])
         self.assertFalse(meta["has_prev"])
 
+    def test_search_reads_get_a_separate_higher_rate_limit_bucket(self):
+        ctx = backend_app.AccessContext(tier="anonymous")
+        for path in ("/v1/sections", "/v1/search/agreements", "/v1/tax-clauses"):
+            with self.app.test_request_context(f"{path}?page=42", method="GET"):
+                key, limit = backend_app._apply_search_read_rate_limit(ctx, "anon:ip", 60)
+            self.assertEqual(limit, 300)
+            # A distinct key prefix means search reads do not share the count
+            # bucket with — or starve — other /v1 traffic.
+            self.assertTrue(key.startswith("search:"))
+        with self.app.test_request_context("/v1/filter-options/deal_type", method="GET"):
+            _key, limit = backend_app._apply_search_read_rate_limit(ctx, "anon:ip", 60)
+        self.assertEqual(limit, 300)
+
+    def test_search_read_rate_limits_scale_with_tier(self):
+        with self.app.test_request_context("/v1/search/agreements?page=2", method="GET"):
+            self.assertEqual(
+                backend_app._apply_search_read_rate_limit(
+                    backend_app.AccessContext(tier="user"), "user:u", 120
+                )[1],
+                600,
+            )
+            self.assertEqual(
+                backend_app._apply_search_read_rate_limit(
+                    backend_app.AccessContext(tier="api_key"), "api_key:k", 300
+                )[1],
+                1200,
+            )
+
+    def test_non_search_requests_keep_their_base_rate_limit(self):
+        ctx = backend_app.AccessContext(tier="anonymous")
+        with self.app.test_request_context("/v1/auth/me", method="GET"):
+            self.assertEqual(
+                backend_app._apply_search_read_rate_limit(ctx, "anon:ip", 60),
+                ("anon:ip", 60),
+            )
+        # A write to a search path is not a search read and is not elevated.
+        with self.app.test_request_context("/v1/sections", method="POST"):
+            self.assertEqual(
+                backend_app._apply_search_read_rate_limit(ctx, "anon:ip", 60),
+                ("anon:ip", 60),
+            )
+
     def test_csrf_required_cookie_transport(self):
         os.environ["AUTH_SESSION_TRANSPORT"] = "cookie"
         with self.app.test_request_context("/v1/auth/logout", method="POST"):

--- a/backend/tests/test_search_counts.py
+++ b/backend/tests/test_search_counts.py
@@ -1,0 +1,132 @@
+import unittest
+from threading import Lock
+from unittest.mock import MagicMock
+
+from backend.search_counts import (
+    build_search_count_cache_key,
+    cached_exact_query_count,
+    exact_query_count,
+)
+
+
+def _to_int(value: object, *, default: int = 0) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _fake_query(count_value: int) -> MagicMock:
+    query = MagicMock()
+    ordered = MagicMock()
+    query.order_by.return_value = ordered
+    ordered.count.return_value = count_value
+    return query
+
+
+class BuildSearchCountCacheKeyTests(unittest.TestCase):
+    def test_pagination_and_sort_and_count_mode_do_not_change_key(self):
+        # The total depends only on the filter signature, so page/sort/count_mode
+        # must map to the same cache entry (that is what lets pages share a count).
+        page_one = {
+            "page": 1,
+            "page_size": 10,
+            "sort_by": "year",
+            "sort_direction": "asc",
+            "count_mode": "auto",
+            "include_dump": True,
+            "target": ["Acme"],
+        }
+        deep_page = {
+            "page": 9,
+            "page_size": 50,
+            "sort_by": "target",
+            "sort_direction": "desc",
+            "count_mode": "exact",
+            "include_dump": False,
+            "target": ["Acme"],
+        }
+        self.assertEqual(
+            build_search_count_cache_key("sections", page_one),
+            build_search_count_cache_key("sections", deep_page),
+        )
+
+    def test_changing_a_filter_changes_the_key(self):
+        self.assertNotEqual(
+            build_search_count_cache_key("sections", {"target": ["Acme"]}),
+            build_search_count_cache_key("sections", {"target": ["Other"]}),
+        )
+
+    def test_list_filter_order_does_not_change_key(self):
+        self.assertEqual(
+            build_search_count_cache_key("sections", {"target": ["A", "B"]}),
+            build_search_count_cache_key("sections", {"target": ["B", "A"]}),
+        )
+
+    def test_scope_separates_otherwise_identical_filters(self):
+        args = {"target": ["Acme"]}
+        self.assertNotEqual(
+            build_search_count_cache_key("agreements_search:direct", args),
+            build_search_count_cache_key("agreements_search:clause", args),
+        )
+
+
+class CachedExactQueryCountTests(unittest.TestCase):
+    def _call(
+        self,
+        query: object,
+        cache: dict[str, tuple[float, int]],
+        cache_key: str | None,
+        now,
+        ttl: float = 120.0,
+    ) -> int:
+        return cached_exact_query_count(
+            query=query,
+            cache_key=cache_key,
+            cache=cache,
+            lock=Lock(),
+            ttl_seconds=ttl,
+            max_keys=100,
+            to_int=_to_int,
+            now=now,
+        )
+
+    def test_hit_within_ttl_reuses_value_without_recounting(self):
+        query = _fake_query(42)
+        cache: dict[str, tuple[float, int]] = {}
+        clock = [1000.0]
+
+        self.assertEqual(self._call(query, cache, "k", lambda: clock[0]), 42)
+        # A recount would now observe a different value; the cache must not.
+        query.order_by.return_value.count.return_value = 999
+        clock[0] = 1050.0
+        self.assertEqual(self._call(query, cache, "k", lambda: clock[0]), 42)
+        self.assertEqual(query.order_by.return_value.count.call_count, 1)
+
+    def test_value_is_recomputed_after_ttl_expiry(self):
+        query = _fake_query(42)
+        cache: dict[str, tuple[float, int]] = {}
+        clock = [1000.0]
+
+        self.assertEqual(self._call(query, cache, "k", lambda: clock[0], ttl=10.0), 42)
+        query.order_by.return_value.count.return_value = 99
+        clock[0] = 1020.0
+        self.assertEqual(self._call(query, cache, "k", lambda: clock[0], ttl=10.0), 99)
+
+    def test_none_cache_key_always_counts_fresh(self):
+        query = _fake_query(7)
+        cache: dict[str, tuple[float, int]] = {}
+
+        self.assertEqual(self._call(query, cache, None, lambda: 0.0), 7)
+        self.assertEqual(cache, {})
+        query.order_by.return_value.count.return_value = 8
+        self.assertEqual(self._call(query, cache, None, lambda: 0.0), 8)
+
+    def test_exact_query_count_drops_order_by(self):
+        query = _fake_query(5)
+        self.assertEqual(exact_query_count(query, _to_int), 5)
+        query.order_by.assert_called_once_with(None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Paginated search re-ran an exact `COUNT(*)` on **every page**, and on `latest_sections_search` (~1M rows) a filtered count was a cold full-table scan (measured **7.3s**, climbing toward 30s with multiple filters). This makes search fast without changing any result counts.

## What

**1. Cache exact result counts** (`backend/search_counts.py`)
A search's match count depends only on its filter signature, so it's identical on every page. Memoize the exact `COUNT(*)` per signature (scoped to the active data dump) so paging one search counts **once** and reuses the identical exact total across pages. Wired into the agreements, sections, and tax-clauses search endpoints.
- **No count semantics change.** The sections estimate / table-estimate / `filtered_lower_bound` paths are untouched; only the existing exact-`COUNT` call sites are wrapped. `count_mode=exact` stays authoritative (bypasses the cache).
- Per-`(filter-signature, dump_version)` key, 120s TTL, in-process, bounded size. Cleared in test `setUp`.

**2. Agreement date filters** — wire `year_min` / `year_max` / `filed_after` / `filed_before` into both agreement search query builders (they were already in the schema but unused). Uses the existing, indexed `filing_date` column.

**3. Search read rate limits** — give read-only search GETs their own higher-ceiling bucket (separate key prefix; anon 300 / user 600 / api_key 1200 per minute) so deep pagination isn't throttled by, and doesn't starve, the shared per-tier `/v1` limit. Purely additive.

## Anti-regression
The counts are exact and identical on every page — a dedicated test pages through a 10-row result at page_size 3 and asserts `total_count == 10` on pages 1–4 and that page 2 never collapses to the "p to q of q+1" lower bound that earlier count rewrites regressed into.

## Deployment notes
- **No new table or column dependency** — queries the same schema as current `main`, so it can't break prod on a missing table; merge order is not safety-critical.
- Related DB indexes (`transaction_price_*` and low-cardinality filter columns on `latest_sections_search`, plus a covering `clauses` index) were applied to the data source so they ride the next dump into prod. The code is correct with or without them; they only affect speed.

## Validation
- `python -m unittest discover backend/tests` → **315 passed** (incl. 15 new).
- `basedpyright` on changed files → **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)