### PR TITLE
Temporarily lock down data API and registration to existing accounts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -113,6 +113,7 @@ from backend.mcp.routes import McpDeps, register_mcp_routes
 from backend.core.config import (
     app_config_map as _app_config_map,
     configure_app as _configure_app_core,
+    temporary_access_lockdown_enabled as _temporary_access_lockdown_enabled,
 )
 from backend.core.errors import (
     json_error as _json_error,
@@ -887,6 +888,61 @@ def _current_access_context() -> AccessContext:
     return AccessContext(tier="anonymous")
 
 
+# --- Temporary July access restrictions -------------------------------------
+# New account creation is disabled and the data API is limited to accounts that
+# already existed before the current day, surfaced in-app as a "check back in
+# July" notice. To reopen access, remove _temporary_access_gate (and its
+# before_request registration in _register_request_hooks) plus the OAuth
+# register guard in backend/routes/auth/__init__.py.
+_REGISTRATION_DISABLED_MESSAGE = (
+    "New user creation is temporarily disabled. Please check back in July."
+)
+_DATA_API_DISABLED_MESSAGE = (
+    "This API is temporarily disabled for non-authenticated users. "
+    "Please check back in July."
+)
+
+
+def _access_account_predates_today(ctx: AccessContext) -> bool:
+    """True only for an authenticated account created before the current UTC day."""
+    if not ctx.is_authenticated or ctx.user_id is None:
+        return False
+    if _auth_is_mocked():
+        user = _mock_auth.get_user(ctx.user_id)
+    elif _auth_db_is_configured():
+        try:
+            user = db.session.get(AuthUser, ctx.user_id)
+        except SQLAlchemyError:
+            return False
+    else:
+        return False
+    created_at = getattr(user, "created_at", None) if user is not None else None
+    if not isinstance(created_at, datetime):
+        return False
+    return created_at.date() < _utc_today()
+
+
+def _temporary_access_gate() -> None:
+    """Block new registration and restrict the data API to pre-today accounts."""
+    if not _temporary_access_lockdown_enabled():
+        return
+    if request.method == "OPTIONS":
+        return
+    path = request.path
+    if request.method == "POST" and path == "/v1/auth/signup/password":
+        abort(403, description=_REGISTRATION_DISABLED_MESSAGE)
+    # Only the data API is gated; /v1/auth/* (sign-in, session, captcha, etc.)
+    # stays reachable so existing users can still authenticate.
+    if not path.startswith("/v1/") or path.startswith("/v1/auth/"):
+        return
+    ctx = getattr(g, "access_ctx", None)
+    if not isinstance(ctx, AccessContext):
+        ctx = _current_access_context()
+    if _access_account_predates_today(ctx):
+        return
+    abort(403, description=_DATA_API_DISABLED_MESSAGE)
+
+
 def _create_api_key(*, user_id: str, name: str | None) -> tuple[ApiKey, str]:
     token = f"pdcts_{uuid.uuid4().hex}{uuid.uuid4().hex}"
     prefix = token[: 6 + 12]
@@ -1321,6 +1377,8 @@ def _register_request_hooks(target_app: Flask) -> None:
         populate_dump_version=_populate_dump_version,
         attach_dump_version_header=_attach_dump_version_header,
     )
+    # Temporary July gate; registered after the core guard so g.access_ctx is set.
+    _temp_access_gate: object = target_app.before_request(_temporary_access_gate)
 
 # Legacy helper names kept so route dependency wiring and tests can import one app module.
 _encode_agreements_cursor = _core_encode_agreements_cursor

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -151,6 +151,21 @@ def max_content_length() -> int:
     return 1 * 1024 * 1024
 
 
+def temporary_access_lockdown_enabled() -> bool:
+    """TEMPORARY (July reopen): when enabled, new account creation is blocked and
+    the data API is limited to accounts created before the current day. Enabled by
+    default so production deploys pick it up without extra config; set
+    TEMPORARY_ACCESS_LOCKDOWN=0 to disable (the test suite does this to exercise
+    the underlying data API anonymously)."""
+    return os.environ.get("TEMPORARY_ACCESS_LOCKDOWN", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+        "",
+    }
+
+
 def _expose_swagger_ui() -> bool:
     # Swagger UI pulls scripts from cdn.jsdelivr.net (not in our CSP) and
     # enumerates every authenticated endpoint with parameter schemas — useful

--- a/backend/routes/auth/__init__.py
+++ b/backend/routes/auth/__init__.py
@@ -23,6 +23,7 @@ from backend.auth.mcp_runtime import (
     McpAuthError,
     mcp_oidc_issuer,
 )
+from backend.core.config import temporary_access_lockdown_enabled
 from backend.routes.auth.cookies import (
     _clear_zitadel_link_cookie,
     _clear_zitadel_pending_cookie,
@@ -302,6 +303,16 @@ def register_auth_routes(app: Flask, *, deps: AuthDeps) -> Blueprint:
         notification_provider: str | None = None,
     ):
         action, user = _resolve_user_from_external_identity(external_identity=external_identity)
+        if action == "register" and temporary_access_lockdown_enabled():
+            # TEMPORARY (July reopen): new account creation is disabled, so
+            # discard the just-created user/link instead of provisioning it.
+            deps.db.session.rollback()
+            abort(
+                403,
+                description=(
+                    "New user creation is temporarily disabled. Please check back in July."
+                ),
+            )
         claims = getattr(external_identity, "claims", None)
         signup_first_name = claims.get("given_name") if isinstance(claims, dict) else None
         signup_last_name = claims.get("family_name") if isinstance(claims, dict) else None

--- a/backend/tests/test_api_validation.py
+++ b/backend/tests/test_api_validation.py
@@ -6,6 +6,7 @@ import unittest
 
 def _set_default_env() -> None:
     os.environ.setdefault("SKIP_MAIN_DB_REFLECTION", "1")
+    os.environ.setdefault("TEMPORARY_ACCESS_LOCKDOWN", "0")
     os.environ.setdefault("MARIADB_USER", "root")
     os.environ.setdefault("MARIADB_PASSWORD", "password")
     os.environ.setdefault("MARIADB_HOST", "127.0.0.1")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -17,6 +17,7 @@ from sqlalchemy import text
 
 def _set_default_env() -> None:
     os.environ["SKIP_MAIN_DB_REFLECTION"] = "1"
+    os.environ["TEMPORARY_ACCESS_LOCKDOWN"] = "0"
     os.environ["MARIADB_USER"] = "root"
     os.environ["MARIADB_PASSWORD"] = "password"
     os.environ["MARIADB_HOST"] = "127.0.0.1"

--- a/backend/tests/test_favorites.py
+++ b/backend/tests/test_favorites.py
@@ -9,6 +9,7 @@ from sqlalchemy import text
 
 def _set_default_env() -> None:
     os.environ["SKIP_MAIN_DB_REFLECTION"] = "1"
+    os.environ["TEMPORARY_ACCESS_LOCKDOWN"] = "0"
     os.environ["MARIADB_USER"] = "root"
     os.environ["MARIADB_PASSWORD"] = "password"
     os.environ["MARIADB_HOST"] = "127.0.0.1"

--- a/backend/tests/test_main_routes.py
+++ b/backend/tests/test_main_routes.py
@@ -13,6 +13,7 @@ from sqlalchemy.dialects import mysql as mysql_dialect
 
 def _set_default_env(main_db_uri: str, auth_db_uri: str) -> None:
     os.environ["SKIP_MAIN_DB_REFLECTION"] = "1"
+    os.environ["TEMPORARY_ACCESS_LOCKDOWN"] = "0"
     os.environ["MAIN_DATABASE_URI"] = main_db_uri
     os.environ["MAIN_DB_SCHEMA"] = ""
     os.environ.setdefault("MARIADB_USER", "root")

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -190,6 +190,7 @@ def _normalized_capabilities_snapshot(payload: dict[str, object]) -> dict[str, o
 
 def _set_default_env(main_db_uri: str, auth_db_uri: str) -> None:
     os.environ["SKIP_MAIN_DB_REFLECTION"] = "1"
+    os.environ["TEMPORARY_ACCESS_LOCKDOWN"] = "0"
     os.environ["MAIN_DATABASE_URI"] = main_db_uri
     os.environ["MAIN_DB_SCHEMA"] = ""
     os.environ.setdefault("MARIADB_USER", "root")

--- a/backend/tests/test_mcp_oauth_runtime.py
+++ b/backend/tests/test_mcp_oauth_runtime.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 def _set_default_env(*, auth_db_uri: str) -> None:
     os.environ["SKIP_MAIN_DB_REFLECTION"] = "1"
+    os.environ["TEMPORARY_ACCESS_LOCKDOWN"] = "0"
     os.environ["MARIADB_USER"] = "root"
     os.environ["MARIADB_PASSWORD"] = "password"
     os.environ["MARIADB_HOST"] = "127.0.0.1"

--- a/backend/tests/test_pagination_and_access.py
+++ b/backend/tests/test_pagination_and_access.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import SAWarning
 
 def _set_default_env() -> None:
     os.environ.setdefault("SKIP_MAIN_DB_REFLECTION", "1")
+    os.environ.setdefault("TEMPORARY_ACCESS_LOCKDOWN", "0")
     os.environ.setdefault("MARIADB_USER", "root")
     os.environ.setdefault("MARIADB_PASSWORD", "password")
     os.environ.setdefault("MARIADB_HOST", "127.0.0.1")

--- a/backend/tests/test_route_contracts.py
+++ b/backend/tests/test_route_contracts.py
@@ -5,6 +5,7 @@ import unittest
 
 def _set_default_env() -> None:
     os.environ.setdefault("SKIP_MAIN_DB_REFLECTION", "1")
+    os.environ.setdefault("TEMPORARY_ACCESS_LOCKDOWN", "0")
     os.environ.setdefault("MARIADB_USER", "root")
     os.environ.setdefault("MARIADB_PASSWORD", "password")
     os.environ.setdefault("MARIADB_HOST", "127.0.0.1")

--- a/backend/tests/test_temporary_access_gate.py
+++ b/backend/tests/test_temporary_access_gate.py
@@ -1,0 +1,109 @@
+import os
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+
+def _set_default_env() -> None:
+    os.environ.setdefault("SKIP_MAIN_DB_REFLECTION", "1")
+    os.environ.setdefault("MARIADB_USER", "root")
+    os.environ.setdefault("MARIADB_PASSWORD", "password")
+    os.environ.setdefault("MARIADB_HOST", "127.0.0.1")
+    os.environ.setdefault("MARIADB_DATABASE", "pdx")
+    os.environ.setdefault("AUTH_SECRET_KEY", "test-auth-secret")
+    os.environ.setdefault("PUBLIC_API_BASE_URL", "http://localhost:5000")
+    os.environ.setdefault("PUBLIC_FRONTEND_BASE_URL", "http://localhost:8080")
+    os.environ.setdefault("GOOGLE_OAUTH_CLIENT_ID", "test-google-client-id")
+    os.environ.setdefault("GOOGLE_OAUTH_CLIENT_SECRET", "test-google-client-secret")
+    os.environ.setdefault("AUTH_SESSION_TRANSPORT", "bearer")
+
+
+_set_default_env()
+
+_AUTH_DB_TEMP = tempfile.NamedTemporaryFile(prefix="pandects_gate_", suffix=".sqlite", delete=False)
+_AUTH_DB_TEMP.close()
+os.environ.setdefault("AUTH_DATABASE_URI", f"sqlite:///{_AUTH_DB_TEMP.name}")
+
+
+from backend.app import create_test_app, db  # noqa: E402
+import backend.app as backend_app  # noqa: E402
+
+
+# The gate reads TEMPORARY_ACCESS_LOCKDOWN per-request, so each test forces the
+# value it needs and patch.dict restores the suite-wide default afterwards.
+_LOCKDOWN_ON = {"TEMPORARY_ACCESS_LOCKDOWN": "1"}
+
+
+class TemporaryAccessGateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.app = create_test_app(
+            config_overrides={
+                "SQLALCHEMY_BINDS": {"auth": f"sqlite:///{_AUTH_DB_TEMP.name}"},
+            }
+        )
+        with cls.app.app_context():
+            db.create_all(bind_key="auth")
+
+    def _seed_user(self, *, user_id: str, email: str, created_at: datetime) -> None:
+        with self.app.app_context():
+            user = backend_app.AuthUser()
+            user.id = user_id
+            user.email = email
+            user.password_hash = "not-used"
+            user.email_verified_at = created_at
+            user.created_at = created_at
+            db.session.merge(user)
+            db.session.commit()
+
+    @patch.dict(os.environ, _LOCKDOWN_ON)
+    def test_anonymous_data_api_blocked(self):
+        client = self.app.test_client()
+        res = client.get("/v1/agreements")
+        self.assertEqual(res.status_code, 403)
+        self.assertIn("temporarily disabled", res.get_json().get("message", ""))
+
+    @patch.dict(os.environ, _LOCKDOWN_ON)
+    def test_password_signup_blocked(self):
+        client = self.app.test_client()
+        res = client.post("/v1/auth/signup/password", json={"email": "x@y.z", "password": "pw"})
+        self.assertEqual(res.status_code, 403)
+        self.assertIn("New user creation is temporarily disabled", res.get_json().get("message", ""))
+
+    @patch.dict(os.environ, _LOCKDOWN_ON)
+    def test_auth_endpoints_are_not_gated(self):
+        # /v1/auth/* must stay reachable so existing users can still sign in;
+        # anonymous /me reaches the handler and returns 401, not the gate's 403.
+        client = self.app.test_client()
+        res = client.get("/v1/auth/me")
+        self.assertEqual(res.status_code, 401)
+
+    def test_predates_today_helper(self):
+        now = backend_app._utc_now()
+        yesterday = now - timedelta(days=1)
+        self._seed_user(
+            user_id="00000000-0000-0000-0000-0000000000e1",
+            email="existing@example.com",
+            created_at=yesterday,
+        )
+        self._seed_user(
+            user_id="00000000-0000-0000-0000-0000000000e2",
+            email="newtoday@example.com",
+            created_at=now,
+        )
+        with self.app.app_context():
+            existing_ctx = backend_app.AccessContext(
+                tier="user", user_id="00000000-0000-0000-0000-0000000000e1"
+            )
+            today_ctx = backend_app.AccessContext(
+                tier="user", user_id="00000000-0000-0000-0000-0000000000e2"
+            )
+            anon_ctx = backend_app.AccessContext(tier="anonymous")
+            self.assertTrue(backend_app._access_account_predates_today(existing_ctx))
+            self.assertFalse(backend_app._access_account_predates_today(today_ctx))
+            self.assertFalse(backend_app._access_account_predates_today(anon_ctx))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/client/components/AccessGate.tsx
+++ b/frontend/client/components/AccessGate.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+import { useAuth } from "@/hooks/use-auth";
+import { LockdownNotice } from "@/components/LockdownNotice";
+
+// TEMPORARY (July reopen): renders the wrapped data page only for signed-in
+// (existing) accounts; everyone else gets the lockdown notice instead of the
+// API errors a locked-down page would otherwise show. While auth is still
+// resolving we render nothing so the page never fires its (403-bound) requests.
+export function AccessGate({ children }: { children: ReactNode }) {
+  const { status } = useAuth();
+  if (status === "authenticated") {
+    return <>{children}</>;
+  }
+  if (status === "loading") {
+    return null;
+  }
+  return <LockdownNotice />;
+}

--- a/frontend/client/components/LockdownNotice.tsx
+++ b/frontend/client/components/LockdownNotice.tsx
@@ -1,0 +1,31 @@
+import { Link, useLocation } from "react-router-dom";
+import { PageShell } from "@/components/PageShell";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+// TEMPORARY (July reopen): rendered in place of data-driven pages while the API
+// is locked down to existing accounts. See lib/lockdown.ts for the gated paths.
+export function LockdownNotice() {
+  const location = useLocation();
+  const next = `${location.pathname}${location.search}`;
+  return (
+    <PageShell title="Temporarily unavailable" size="md">
+      <Card className="mx-auto w-full max-w-xl border-border bg-card/95 p-6 shadow-sm sm:p-8">
+        <Alert>
+          <AlertTitle>This page is temporarily unavailable</AlertTitle>
+          <AlertDescription>
+            Access is temporarily limited to existing accounts, and new user creation is
+            paused. Please check back in July.
+          </AlertDescription>
+        </Alert>
+        <div className="mt-6 text-center text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Button asChild variant="link" className="h-auto p-0 text-primary">
+            <Link to={`/login?next=${encodeURIComponent(next)}`}>Sign in</Link>
+          </Button>
+        </div>
+      </Card>
+    </PageShell>
+  );
+}

--- a/frontend/client/lib/lockdown.ts
+++ b/frontend/client/lib/lockdown.ts
@@ -1,0 +1,14 @@
+// TEMPORARY (July reopen): paths whose pages hydrate via the locked-down data
+// API. <AccessGate> swaps these for the lockdown notice for visitors who aren't
+// signed in, so they get a clean message instead of API error states. To reopen
+// public access, empty this set (and remove the AccessGate wiring in main.tsx
+// and prerender/entry.tsx).
+export const ACCESS_GATED_PATHS: ReadonlySet<string> = new Set([
+  "/search",
+  "/agreements/:agreementUuid",
+  "/bulk-data",
+  "/agreement-index",
+  "/taxonomy",
+  "/leaderboards",
+  "/trends-analyses",
+]);

--- a/frontend/client/main.tsx
+++ b/frontend/client/main.tsx
@@ -13,9 +13,11 @@ import {
 import { AppLayout } from "@/components/AppLayout";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
+import { AccessGate } from "@/components/AccessGate";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { FavoritesProvider } from "@/contexts/FavoritesContext";
 import { createQueryClient } from "@/lib/query-client";
+import { ACCESS_GATED_PATHS } from "@/lib/lockdown";
 import { ROUTES } from "@/lib/routes";
 
 const App = () => {
@@ -52,6 +54,8 @@ const App = () => {
                           element={
                             route.protected ? (
                               <ProtectedRoute>{element}</ProtectedRoute>
+                            ) : ACCESS_GATED_PATHS.has(route.path) ? (
+                              <AccessGate>{element}</AccessGate>
                             ) : (
                               element
                             )

--- a/frontend/client/pages/Login.tsx
+++ b/frontend/client/pages/Login.tsx
@@ -362,15 +362,9 @@ export default function Login() {
                 </div>
               </form>
 
+              {/* TEMPORARY (July reopen): new account creation is disabled. */}
               <div className="text-center text-sm text-muted-foreground">
-                Need an account?{" "}
-                <Link
-                  to={`/signup?next=${encodeURIComponent(nextPath)}`}
-                  className="font-medium text-primary hover:underline"
-                >
-                  Create one
-                </Link>
-                .
+                New account creation is temporarily disabled. Please check back in July.
               </div>
             </div>
           </Card>

--- a/frontend/client/pages/Signup.tsx
+++ b/frontend/client/pages/Signup.tsx
@@ -1,388 +1,46 @@
-import { FormEvent, useEffect, useMemo, useState } from "react";
-import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
+import { useMemo } from "react";
+import { Link, Navigate, useLocation } from "react-router-dom";
 import { PageShell } from "@/components/PageShell";
-import { LegalAcceptancePrompt } from "@/components/auth/LegalAcceptancePrompt";
-import { TurnstileWidget } from "@/components/TurnstileWidget";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { useAuth } from "@/hooks/use-auth";
-import {
-  fetchCaptchaSiteKey,
-  finalizeZitadelWebsiteAuth,
-  signupWithPassword,
-  startZitadelGoogleWebsiteAuth,
-} from "@/lib/auth-api";
-import { navigateToNextPath, nextPathRequiresDocumentNavigation, safeNextPath } from "@/lib/auth-next";
-import { setSessionToken } from "@/lib/auth-session";
-import { authSessionTransport } from "@/lib/auth-transport";
-import { prewarmAuthBackend, withAuthWakeRetry } from "@/lib/auth-wake";
+import { nextPathRequiresDocumentNavigation, safeNextPath } from "@/lib/auth-next";
 
-type SignupState =
-  | { kind: "form" }
-  | { kind: "legal"; email: string; nextPath: string }
-  | { kind: "verify"; email: string };
-
-function GoogleMark() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5">
-      <path
-        d="M21.805 12.23c0-.68-.061-1.334-.174-1.963H12v3.713h5.498a4.703 4.703 0 0 1-2.04 3.086v2.564h3.3c1.93-1.777 3.047-4.4 3.047-7.4Z"
-        fill="#4285F4"
-      />
-      <path
-        d="M12 22c2.76 0 5.076-.915 6.768-2.47l-3.3-2.563c-.916.614-2.09.977-3.468.977-2.656 0-4.906-1.793-5.711-4.205H2.877v2.646A10.22 10.22 0 0 0 12 22Z"
-        fill="#34A853"
-      />
-      <path
-        d="M6.289 13.739A6.145 6.145 0 0 1 5.97 11.8c0-.674.116-1.328.319-1.939V7.215H2.877A10.197 10.197 0 0 0 1.8 11.8c0 1.627.389 3.168 1.077 4.585l3.412-2.646Z"
-        fill="#FBBC05"
-      />
-      <path
-        d="M12 5.656c1.5 0 2.847.517 3.908 1.534l2.93-2.93C17.07 2.614 14.754 1.6 12 1.6a10.22 10.22 0 0 0-9.123 5.615L6.29 9.86c.805-2.411 3.055-4.204 5.711-4.204Z"
-        fill="#EA4335"
-      />
-    </svg>
-  );
-}
-
+// TEMPORARY (July reopen): new account creation is disabled. Restore the prior
+// signup form (Google + email/password + captcha + legal/verify flow) from
+// version control to re-enable registration.
 export default function Signup() {
-  const { status, refresh } = useAuth();
-  const navigate = useNavigate();
+  const { status } = useAuth();
   const location = useLocation();
   const nextPath = useMemo(
     () => safeNextPath(new URLSearchParams(location.search).get("next")),
     [location.search],
   );
-  const initialEmail = useMemo(
-    () => new URLSearchParams(location.search).get("email") ?? "",
-    [location.search],
-  );
-  const [state, setState] = useState<SignupState>({ kind: "form" });
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [email, setEmail] = useState(initialEmail);
-  const [password, setPassword] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [legalAccepted, setLegalAccepted] = useState(false);
-  const [legalCheckedAtMs, setLegalCheckedAtMs] = useState<number | null>(null);
-  const [captchaSiteKey, setCaptchaSiteKey] = useState<string | null>(null);
-  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
-  const [captchaResolved, setCaptchaResolved] = useState(false);
-
-  useEffect(() => {
-    void prewarmAuthBackend();
-  }, []);
-
-  useEffect(() => {
-    let canceled = false;
-    void withAuthWakeRetry(() => fetchCaptchaSiteKey())
-      .then((result) => {
-        if (canceled) return;
-        if (result.enabled) setCaptchaSiteKey(result.site_key);
-        setCaptchaResolved(true);
-      })
-      .catch(() => {
-        if (canceled) return;
-        // Mark resolved so the submit button is no longer indefinitely
-        // disabled; if the BE actually requires captcha, the submit will
-        // surface a clear 412 captcha_required error.
-        setCaptchaResolved(true);
-      });
-    return () => {
-      canceled = true;
-    };
-  }, []);
-
-  useEffect(() => {
-    if (status !== "authenticated" || !nextPathRequiresDocumentNavigation(nextPath)) {
-      return;
-    }
-    navigateToNextPath(navigate, nextPath, { replace: true });
-  }, [navigate, nextPath, status]);
 
   if (status === "authenticated") {
-    if (nextPathRequiresDocumentNavigation(nextPath)) {
-      return null;
-    }
-    return <Navigate to={nextPath} replace />;
+    return <Navigate to={nextPathRequiresDocumentNavigation(nextPath) ? "/account" : nextPath} replace />;
   }
 
-  const finishSession = async (payload: {
-    next_path: string;
-    session_token?: string;
-  }) => {
-    if (authSessionTransport() === "bearer") {
-      if (!payload.session_token) {
-        throw new Error("Missing session token.");
-      }
-      setSessionToken(payload.session_token);
-    }
-    await refresh();
-    navigateToNextPath(navigate, payload.next_path, { replace: true });
-  };
-
-  const submit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setSubmitting(true);
-    setError(null);
-    try {
-      const result = await signupWithPassword({
-        email,
-        password,
-        first_name: firstName || undefined,
-        last_name: lastName || undefined,
-        next: nextPath,
-        captcha_token: captchaToken ?? undefined,
-      });
-      if (result.status === "legal_required") {
-        setState({
-          kind: "legal",
-          email: result.user.email,
-          nextPath: safeNextPath(result.next_path),
-        });
-        return;
-      }
-      if (result.status === "verification_required") {
-        setState({
-          kind: "verify",
-          email: result.user.email,
-        });
-        return;
-      }
-      await finishSession(result);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  const startGoogle = async () => {
-    setSubmitting(true);
-    setError(null);
-    try {
-      const { authorize_url } = await withAuthWakeRetry(() =>
-        startZitadelGoogleWebsiteAuth(nextPath),
-      );
-      window.location.assign(authorize_url);
-    } catch (err) {
-      setSubmitting(false);
-      setError(err instanceof Error ? err.message : String(err));
-    }
-  };
-
-  const submitLegal = async () => {
-    if (state.kind !== "legal" || !legalCheckedAtMs) return;
-    setSubmitting(true);
-    setError(null);
-    try {
-      const result = await finalizeZitadelWebsiteAuth({
-        checked_at_ms: legalCheckedAtMs,
-        docs: ["tos", "privacy", "license"],
-      });
-      if (result.status === "verification_required") {
-        setState({
-          kind: "verify",
-          email: state.email,
-        });
-        return;
-      }
-      await finishSession(result);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
   return (
-    <PageShell
-      title="Create account"
-      subtitle="Create a Pandects account with email and password, or continue directly with Google."
-      size="md"
-      className="max-w-3xl"
-    >
-      <div className="grid gap-6">
-        {error ? (
-          <Alert variant="destructive">
-            <AlertTitle>
-              {state.kind === "form" ? "Could not create account" : "Could not finish account setup"}
-            </AlertTitle>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        ) : null}
-        {state.kind === "legal" ? (
-          <LegalAcceptancePrompt
-            email={state.email}
-            checked={legalAccepted}
-            disabled={submitting}
-            onCheckedChange={(checked) => {
-              setLegalAccepted(checked);
-              setLegalCheckedAtMs(checked ? Date.now() : null);
-            }}
-            onSubmit={() => void submitLegal()}
-            submitLabel={submitting ? "Finishing account setup…" : "Continue"}
-          />
-        ) : state.kind === "verify" ? (
-          <Card className="mx-auto w-full max-w-xl border-border bg-card/95 p-6 shadow-sm">
-            <div className="grid gap-4">
-              <div>
-                <h2 className="text-base font-medium">Check your email</h2>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  We sent a verification link to{" "}
-                  <span className="font-medium text-foreground">{state.email}</span>. Verify your
-                  email to finish activating the account, then sign in.
-                </p>
-              </div>
-              <div className="text-sm text-muted-foreground">
-                Already verified?{" "}
-                <Link
-                  to={`/login?next=${encodeURIComponent(nextPath)}`}
-                  className="text-primary hover:underline"
-                >
-                  Sign in
-                </Link>
-                .
-              </div>
-            </div>
-          </Card>
-        ) : (
-          <Card className="mx-auto w-full max-w-2xl border-border bg-card/95 p-6 shadow-sm sm:p-8">
-            <div className="grid gap-5">
-              <div className="grid gap-6">
-                <div className="flex justify-center">
-                  <Button
-                    onClick={() => void startGoogle()}
-                    disabled={submitting}
-                    variant="outline"
-                    className="h-11 min-w-[17rem] rounded-full border-border bg-white px-5 text-foreground shadow-sm hover:bg-muted/40"
-                  >
-                    <GoogleMark />
-                    {submitting ? "Redirecting…" : "Continue with Google"}
-                  </Button>
-                </div>
-                <div className="flex items-center gap-4 text-[11px] uppercase tracking-[0.24em] text-muted-foreground">
-                  <div className="flex-1 border-t border-border" aria-hidden="true" />
-                  <span className="text-muted-foreground/95">or create an account with email</span>
-                  <div className="flex-1 border-t border-border" aria-hidden="true" />
-                </div>
-              </div>
-              <form className="grid gap-5" onSubmit={submit}>
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <div className="grid gap-2">
-                    <Label
-                      htmlFor="signup-first-name"
-                      className="text-sm font-medium text-foreground/90"
-                    >
-                      First name
-                    </Label>
-                    <Input
-                      id="signup-first-name"
-                      autoComplete="given-name"
-                      value={firstName}
-                      onChange={(event) => setFirstName(event.target.value)}
-                      className="h-11 border-border bg-background"
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <Label
-                      htmlFor="signup-last-name"
-                      className="text-sm font-medium text-foreground/90"
-                    >
-                      Last name
-                    </Label>
-                    <Input
-                      id="signup-last-name"
-                      autoComplete="family-name"
-                      value={lastName}
-                      onChange={(event) => setLastName(event.target.value)}
-                      className="h-11 border-border bg-background"
-                    />
-                  </div>
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="signup-email" className="text-sm font-medium text-foreground/90">
-                    Email
-                  </Label>
-                  <Input
-                    id="signup-email"
-                    type="email"
-                    autoComplete="email"
-                    value={email}
-                    onChange={(event) => setEmail(event.target.value)}
-                    required
-                    className="h-11 border-border bg-background"
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label
-                    htmlFor="signup-password"
-                    className="text-sm font-medium text-foreground/90"
-                  >
-                    Password
-                  </Label>
-                  <Input
-                    id="signup-password"
-                    type="password"
-                    autoComplete="new-password"
-                    value={password}
-                    onChange={(event) => setPassword(event.target.value)}
-                    required
-                    className="h-11 border-border bg-background"
-                  />
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  When you continue, you'll be prompted to accept our terms; then, you can finish
-                  activation by verifying your email address.
-                </p>
-                {captchaSiteKey ? (
-                  <TurnstileWidget
-                    siteKey={captchaSiteKey}
-                    onToken={setCaptchaToken}
-                    onError={setError}
-                  />
-                ) : null}
-                <div className="flex justify-center pt-1">
-                  <Button
-                    type="submit"
-                    disabled={
-                      submitting ||
-                      !captchaResolved ||
-                      (captchaSiteKey !== null && !captchaToken)
-                    }
-                    className="min-w-[12rem] rounded-full px-6"
-                  >
-                    {submitting ? (
-                      <span className="inline-flex items-center gap-2">
-                        <LoadingSpinner size="sm" aria-label="Creating account" />
-                        Creating account…
-                      </span>
-                    ) : (
-                      "Create account"
-                    )}
-                  </Button>
-                </div>
-              </form>
-
-              <div className="text-center text-sm text-muted-foreground">
-                Already have an account?{" "}
-                <Link
-                  to={`/login?next=${encodeURIComponent(nextPath)}`}
-                  className="font-medium text-primary hover:underline"
-                >
-                  Sign in
-                </Link>
-                .
-              </div>
-            </div>
-          </Card>
-        )}
-      </div>
+    <PageShell title="Create account" size="md" className="max-w-3xl">
+      <Card className="mx-auto w-full max-w-xl border-border bg-card/95 p-6 shadow-sm sm:p-8">
+        <Alert>
+          <AlertTitle>Account creation is temporarily disabled</AlertTitle>
+          <AlertDescription>
+            New user creation is temporarily disabled. Please check back in July.
+          </AlertDescription>
+        </Alert>
+        <div className="mt-6 text-center text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link
+            to={`/login?next=${encodeURIComponent(nextPath)}`}
+            className="font-medium text-primary hover:underline"
+          >
+            Sign in
+          </Link>
+          .
+        </div>
+      </Card>
     </PageShell>
   );
 }

--- a/frontend/prerender/entry.tsx
+++ b/frontend/prerender/entry.tsx
@@ -4,8 +4,10 @@ import { StaticRouter } from "react-router-dom/server";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppLayout } from "@/components/AppLayout";
+import { AccessGate } from "@/components/AccessGate";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { createQueryClient } from "@/lib/query-client";
+import { ACCESS_GATED_PATHS } from "@/lib/lockdown";
 import { PRERENDER_ROUTES } from "@shared/route-manifest.mjs";
 
 import About from "@/pages/About";
@@ -63,7 +65,13 @@ export function renderPage(pathname: string): string {
                   <Route
                     key={route.pathname}
                     path={route.pathname}
-                    element={PRERENDER_COMPONENTS[route.pathname]}
+                    element={
+                      ACCESS_GATED_PATHS.has(route.pathname) ? (
+                        <AccessGate>{PRERENDER_COMPONENTS[route.pathname]}</AccessGate>
+                      ) : (
+                        PRERENDER_COMPONENTS[route.pathname]
+                      )
+                    }
                   />
                 ))}
               </Route>


### PR DESCRIPTION
## Summary

Temporary, reversible "check back in July" access lockdown: the data API and new-user registration are limited to existing accounts, and data-driven pages show one consistent notice instead of API errors.

### Backend
- A `before_request` gate ([app.py](backend/app.py)) blocks the `/v1` data API (except `/v1/auth/*`) unless the caller is an authenticated account **created before the current UTC day**; also blocks `POST /v1/auth/signup/password` and new-account creation in the Zitadel/Google OAuth completion flow.
- Controlled by `TEMPORARY_ACCESS_LOCKDOWN` (default **on**, so deploys activate it with no extra config). `/v1/auth/*` and OPTIONS preflights stay reachable so existing users can still sign in.

### Frontend
- `AccessGate` + `LockdownNotice` render one consistent notice for non-signed-in visitors on data-driven routes (search, agreements, bulk-data, agreement-index, taxonomy, leaderboards, trends-analyses). **Page shells are unchanged** — wiring lives in the client router and the prerender entry, keyed off a single `ACCESS_GATED_PATHS` set.
- Signup shows a "registration disabled" notice; Login drops the create-account CTA. Landing/About are not gated (they already hide their one API widget on error).

### Reopen in July
Set `TEMPORARY_ACCESS_LOCKDOWN=0` and empty `ACCESS_GATED_PATHS`; every site is marked `TEMPORARY (July reopen)`.

## Test plan
- `backend`: `basedpyright` 0 errors; `unittest discover backend/tests` → 319 pass, incl. new `test_temporary_access_gate` (anonymous→403, signup→403, `/v1/auth/me`→401 not gated, created-before-today helper). Existing data-API tests run with the flag off to preserve coverage.
- `frontend`: `typecheck` clean, `vitest` 99 pass, `lint` 0 errors, full `npm run build` (prerender + SEO validation for 17 routes) passes. Verified gated prerender output is a clean shell (correct `<title>`, empty body), ungated pages render normally.