### PR TITLE
Make taxonomy_l1/l2/l3 ORM mapping resilient to a missing PRIMARY KEY

### DIFF
--- a/backend/models/main_db.py
+++ b/backend/models/main_db.py
@@ -592,14 +592,22 @@ class XML(db.Model):
     latest: ClassVar[Mapped[int]]
 
 
+# `taxonomy_l1/l2/l3` are seeded out-of-band and have been rebuilt without a
+# PRIMARY KEY (a recreate drops it). In production these tables are reflected, so
+# a missing DB-side PK would otherwise abort ORM mapping ("could not assemble any
+# primary key columns") and crash every worker on boot. Pin `standard_id` as the
+# mapper primary key so boot is independent of whether the live table declares
+# one. (`standard_id` is the natural key and is non-null/unique.)
 class TaxonomyL1(db.Model):
     __table__ = taxonomy_l1_table
+    __mapper_args__ = {"primary_key": [taxonomy_l1_table.c.standard_id]}
     standard_id: ClassVar[Mapped[str]]
     label: ClassVar[Mapped[str | None]]
 
 
 class TaxonomyL2(db.Model):
     __table__ = taxonomy_l2_table
+    __mapper_args__ = {"primary_key": [taxonomy_l2_table.c.standard_id]}
     standard_id: ClassVar[Mapped[str]]
     label: ClassVar[Mapped[str | None]]
     parent_id: ClassVar[Mapped[str | None]]
@@ -607,6 +615,7 @@ class TaxonomyL2(db.Model):
 
 class TaxonomyL3(db.Model):
     __table__ = taxonomy_l3_table
+    __mapper_args__ = {"primary_key": [taxonomy_l3_table.c.standard_id]}
     standard_id: ClassVar[Mapped[str]]
     label: ClassVar[Mapped[str | None]]
     parent_id: ClassVar[Mapped[str | None]]


### PR DESCRIPTION
## Summary
Hardens the backend against the root cause of the 2026-06-20 outage. `taxonomy_l1/l2/l3` are reflected in production and seeded out-of-band (no committed loader); a rebuild recreated them **without a PRIMARY KEY**, so ORM mapping aborted ("could not assemble any primary key columns for mapped table 'taxonomy_l1'") and every gunicorn worker crashed on boot. A code rollback couldn't fix it because the failure is driven by live DB schema, not the deployed diff.

This pins `standard_id` (the natural, non-null/unique key) as the mapper primary key via `__mapper_args__` in [main_db.py](backend/models/main_db.py), so boot no longer depends on the live table declaring a PK. This is the documented SQLAlchemy pattern for reflected PK-less tables and protects against any rebuild path (manual, notebook, or future ETL).

The PKs were also re-added directly on the local and prod DBs during the incident; this change makes the app safe even if a future rebuild drops them again.

## Test plan
- `basedpyright` project-wide: 0 errors.
- `unittest discover backend/tests`: all pass.
- **End-to-end proof on the local DB**: dropped `PRIMARY KEY` on all three tables (confirmed 0 PKs), booted the production reflection path (`SKIP_MAIN_DB_REFLECTION=0 ENABLE_MAIN_DB_REFLECTION=1`) → app boots and `inspect(TaxonomyL1).primary_key == [standard_id]`; restored the PKs afterward.

Scope: applies to `taxonomy_l1/l2/l3` (the tables that broke). `tax_clause_taxonomy_l*` retain their PKs and a committed provenance; can get the same treatment later if desired.