### PR TITLE
Add 12 audited negative pairs to the dedupe eval as committed fixture

### DIFF
--- a/etl/src/etl/utils/dedupe_labeled_negatives_20260805.json
+++ b/etl/src/etl/utils/dedupe_labeled_negatives_20260805.json
@@ -1,0 +1,122 @@
+[
+ {
+  "new_agreement_uuid": "0c1a8bbe-02a8-562b-b637-3eac1c5819e3",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/1798270/000110465924056553/ionm-20231231xex10d25.htm",
+  "existing_agreement_uuid": "e16d62a1-0577-5ad2-a96c-6b34f9e0fc7f",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/1382574/000149315223002126/ex10-1.htm",
+  "jaccard": 0.96875,
+  "containment": 0.9852748771877854,
+  "fingerprint_match": false,
+  "reason": "party_metadata_conflict"
+ },
+ {
+  "new_agreement_uuid": "1003a6f4-ca70-5101-a77c-2824ed79495c",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/1805385/000121390021013856/ea137148ex2-1_newholdinves.htm",
+  "existing_agreement_uuid": "ad9c0b29-0b4f-562d-950b-523ad891040b",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/1828522/000119312521174376/d157368dex21.htm",
+  "jaccard": 0.3359375,
+  "containment": 0.9750514655259211,
+  "fingerprint_match": false,
+  "reason": "party_metadata_conflict"
+ },
+ {
+  "new_agreement_uuid": "12f666e7-351c-5f89-b0ef-eea033fff4a3",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/1364479/000119312525030725/d936893dex21.htm",
+  "existing_agreement_uuid": "3a0cf85f-894c-5c49-9f48-703f051c9cd2",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/1339605/000119312525005785/d866014dex21.htm",
+  "jaccard": 0.8984375,
+  "containment": 0.9800789167261104,
+  "fingerprint_match": false,
+  "reason": "party_metadata_conflict"
+ },
+ {
+  "new_agreement_uuid": "242a1f02-9112-5a37-aac5-3cbfb49272c0",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/1844419/000110465924081236/tm2419754d1_ex2-1.htm",
+  "existing_agreement_uuid": "62619457-75ff-5f3d-a454-c3cc512cb482",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/1844419/000110465923089661/tm2323399d1_ex2-1.htm",
+  "jaccard": 0.7734375,
+  "containment": 0.9869085044078506,
+  "fingerprint_match": false,
+  "reason": "party_metadata_conflict"
+ },
+ {
+  "new_agreement_uuid": "3652de8d-a05b-541d-86fc-d4f477004555",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/16875/000119312521088339/d146726dex21.htm",
+  "existing_agreement_uuid": "acd2c7b6-f85d-5b28-9569-fca073568f33",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/54480/000119312521274158/d233365dex21.htm",
+  "jaccard": 0.9921875,
+  "containment": 0.996078431372549,
+  "fingerprint_match": false,
+  "reason": "dated_as_of_mismatch"
+ },
+ {
+  "new_agreement_uuid": "3c5be027-d2fd-5725-8689-dd4788dc3eef",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/1808665/000110465926074619/tm2617883d1_ex2-1.htm",
+  "existing_agreement_uuid": "e5fab5d2-108e-58d6-9049-1e34cca19e5d",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/1808665/000110465926041236/tm2611405d1_ex2-1.htm",
+  "jaccard": 0.6015625,
+  "containment": 0.9749889347031006,
+  "fingerprint_match": false,
+  "reason": "party_metadata_conflict"
+ },
+ {
+  "new_agreement_uuid": "40b0a310-515f-540c-b8bf-56ef7cc5d8b9",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/1918102/000121390025086894/ea025644301ex2-1_deep.htm",
+  "existing_agreement_uuid": "de60f374-7cd3-5f2b-9624-f55ae60f5c01",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/2075109/000121390026062961/ea029221401ex2-1.htm",
+  "jaccard": 0.9375,
+  "containment": 0.9842654908331401,
+  "fingerprint_match": false,
+  "reason": "party_metadata_conflict"
+ },
+ {
+  "new_agreement_uuid": "5b5798c1-db9b-5b0f-9d17-9023a42502b5",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/1819584/000121390021007256/ea134805ex2-1_tortoiseacq2.htm",
+  "existing_agreement_uuid": "70f2d38f-cdf2-5da7-aa24-24d050756e00",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/1861622/000149315223006133/ex2-1.htm",
+  "jaccard": 0.484375,
+  "containment": 0.9717633123905655,
+  "fingerprint_match": false,
+  "reason": "party_metadata_conflict"
+ },
+ {
+  "new_agreement_uuid": "5c59a0a7-b56c-56e3-812b-ed7cb1567c6f",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/1741830/000121390025038076/ea024018201ex2-1_kronos.htm",
+  "existing_agreement_uuid": "8dcfe199-276c-5b88-a8d7-f3509970dd85",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/1564824/000119312525070926/d923788dex21.htm",
+  "jaccard": 0.65625,
+  "containment": 0.9760177545044876,
+  "fingerprint_match": false,
+  "reason": "party_metadata_conflict"
+ },
+ {
+  "new_agreement_uuid": "5c59a0a7-b56c-56e3-812b-ed7cb1567c6f",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/1741830/000121390025038076/ea024018201ex2-1_kronos.htm",
+  "existing_agreement_uuid": "935fa280-edeb-5b7b-bfb5-375376e307c7",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/1496323/000119312525153576/d82329dex21.htm",
+  "jaccard": 0.7109375,
+  "containment": 0.984996117873713,
+  "fingerprint_match": false,
+  "reason": "party_metadata_conflict"
+ },
+ {
+  "new_agreement_uuid": "6f3a18a2-0179-5685-80b9-9451159f58f5",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/1739410/000119312526249790/d19106dex21.htm",
+  "existing_agreement_uuid": "b19c8c95-a111-5933-9964-2854b3e1353f",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/1739410/000119312526084444/d108429dex21.htm",
+  "jaccard": 0.9375,
+  "containment": 0.9744023488904305,
+  "fingerprint_match": false,
+  "reason": "dated_as_of_mismatch"
+ },
+ {
+  "new_agreement_uuid": "da7bf58b-d95b-5549-88ef-5aa19dfb11b4",
+  "new_url": "https://www.sec.gov/Archives/edgar/data/1864032/000121465924011506/ex2_1.htm",
+  "existing_agreement_uuid": "ebd2b75e-8b5c-5ff0-ab18-1cd97ab7253d",
+  "existing_url": "https://www.sec.gov/Archives/edgar/data/1799191/000110465921086393/tm2120803d3_ex2-1.htm",
+  "jaccard": 0.3828125,
+  "containment": 1.0,
+  "fingerprint_match": false,
+  "reason": "party_metadata_conflict"
+ }
+]

--- a/etl/src/etl/utils/eval_dedupe_similarity.py
+++ b/etl/src/etl/utils/eval_dedupe_similarity.py
@@ -1,18 +1,28 @@
 # pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAny=false, reportDeprecated=false, reportExplicitAny=false, reportMissingTypeStubs=false, reportPrivateUsage=false
 """Evaluate the dedupe similarity metric and decision policy on labeled pairs.
 
-Ground truth (two audited batches):
+Ground truth (four audited batches):
 - Batch A: pdx.dedupe_plan_20260805 — auto_tier=1: 171 true-dupe pairs
   (loser text in pdx.dedupe_bak_20260805_pages); auto_tier=0: 5 non-dupe
-  pairs, including 4 distinct-deal traps.
+  pairs, including 4 distinct-deal traps. One tier-0 pair was later
+  re-adjudicated as a true dupe by batch C and is skipped here.
 - Batch B: pdx.dedupe_plan_20260805b — 15 confirmed-dupe pairs (loser text in
   pdx.dedupe_bak_20260805b_pages), plus 13 audit-confirmed NON-dupe pairs
   (both sides still live in pdx.pages) hardcoded below — the strongest
   negatives available (SPAC boilerplate and same-accession sibling exhibits
   that defeated the first-cut A&R rule).
+- Batch C: pdx.dedupe_plan_20260805c — 1 confirmed-dupe pair (loser text in
+  pdx.dedupe_bak_20260805c_pages). This re-adjudicates a batch A tier-0
+  pair, so its label overrides batch A's.
+- Batch D: 12 NON-dupe pairs from the 2026-08-05 strong/moderate-similarity
+  review, document-audited as genuinely different deals (both sides live in
+  pdx.pages), committed in dedupe_labeled_negatives_20260805.json. Includes
+  the Wood Sage pair (jaccard ~0.97: same drafter template, different
+  transactions) — the hardest known negative. One pair duplicates a batch A
+  tier-0 negative and is skipped here.
 
-Requirement: ZERO auto-dedupe decisions across all 18 negatives; report recall
-on all 186 positives.
+Requirement: ZERO auto-dedupe decisions across all 28 negatives; report recall
+on all 187 positives.
 
 Compares:
 - OLD metric: Jaccard of the first-20k-char MinHash at the historical 0.85
@@ -27,6 +37,7 @@ Usage (from repo root):
 
 from __future__ import annotations
 
+import json
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -61,11 +72,17 @@ from etl.utils.reset_stuck_agreements import build_engine_from_env
 
 _SCHEMA = "pdx"
 _OLD_THRESHOLD = 0.85
-_PAGE_TABLES = ("pages", "dedupe_bak_20260805_pages", "dedupe_bak_20260805b_pages")
+_PAGE_TABLES = (
+    "pages",
+    "dedupe_bak_20260805_pages",
+    "dedupe_bak_20260805b_pages",
+    "dedupe_bak_20260805c_pages",
+)
 _AGREEMENT_TABLES = (
     "agreements",
     "dedupe_bak_20260805_agreements",
     "dedupe_bak_20260805b_agreements",
+    "dedupe_bak_20260805c_agreements",
 )
 
 # Batch B negatives: 13 pairs the 2026-08-05 audits confirmed as NOT duplicates
@@ -87,6 +104,22 @@ BATCH_B_NEGATIVE_PAIRS: Final[tuple[tuple[str, str], ...]] = (
     ("e33d8023-083a-529b-b540-ceed29bfccd3", "8ceacaf4-face-5fbe-b606-bebaf8f80be7"),
     ("98b2f389-b86f-5b29-ae79-ab9020121a75", "c8365dc6-c530-599c-be83-071700465512"),
 )
+
+# Batch D negatives: 12 pairs from the 2026-08-05 strong/moderate-similarity
+# review, each document-audited as a genuinely different deal. Fields are the
+# audit export's new_agreement_uuid (treated as loser) and
+# existing_agreement_uuid (treated as survivor); both sides live in pdx.pages.
+_BATCH_D_NEGATIVES_FIXTURE: Final[Path] = Path(__file__).with_name(
+    "dedupe_labeled_negatives_20260805.json"
+)
+
+
+def _load_batch_d_negative_pairs() -> list[tuple[str, str]]:
+    rows = json.loads(_BATCH_D_NEGATIVES_FIXTURE.read_text())
+    return [
+        (str(row["new_agreement_uuid"]), str(row["existing_agreement_uuid"]))
+        for row in rows
+    ]
 
 
 @dataclass(frozen=True)
@@ -118,6 +151,17 @@ class PairScore:
 
 
 def _load_pairs(conn: Connection) -> list[LabeledPair]:
+    batch_c_rows = conn.execute(
+        text(
+            f"""
+            SELECT loser_uuid, survivor_uuid
+            FROM {_SCHEMA}.dedupe_plan_20260805c
+            ORDER BY loser_uuid
+            """
+        )
+    ).fetchall()
+    batch_c_pairs = {(str(row[0]), str(row[1])) for row in batch_c_rows}
+
     pairs: list[LabeledPair] = []
     rows = conn.execute(
         text(
@@ -129,10 +173,14 @@ def _load_pairs(conn: Connection) -> list[LabeledPair]:
         )
     ).fetchall()
     for row in rows:
+        pair = (str(row[0]), str(row[1]))
+        if pair in batch_c_pairs:
+            # Batch C re-adjudicated this pair; its label wins.
+            continue
         pairs.append(
             LabeledPair(
-                loser_uuid=str(row[0]),
-                survivor_uuid=str(row[1]),
+                loser_uuid=pair[0],
+                survivor_uuid=pair[1],
                 is_dupe=int(row[2]) == 1,
                 batch="A",
             )
@@ -162,6 +210,28 @@ def _load_pairs(conn: Connection) -> list[LabeledPair]:
                 survivor_uuid=survivor_uuid,
                 is_dupe=False,
                 batch="B",
+            )
+        )
+    for loser_uuid, survivor_uuid in sorted(batch_c_pairs):
+        pairs.append(
+            LabeledPair(
+                loser_uuid=loser_uuid,
+                survivor_uuid=survivor_uuid,
+                is_dupe=True,
+                batch="C",
+            )
+        )
+    seen = {(pair.loser_uuid, pair.survivor_uuid) for pair in pairs}
+    for loser_uuid, survivor_uuid in _load_batch_d_negative_pairs():
+        if (loser_uuid, survivor_uuid) in seen:
+            # Already labeled by an earlier batch (e.g. a batch A tier-0 trap).
+            continue
+        pairs.append(
+            LabeledPair(
+                loser_uuid=loser_uuid,
+                survivor_uuid=survivor_uuid,
+                is_dupe=False,
+                batch="D",
             )
         )
     return pairs
@@ -303,13 +373,15 @@ def _report(scores: list[PairScore]) -> None:
             f"precision={precision:.3f} false_positives={false_pos}/{len(negatives)}"
         )
 
+    def _batch_breakdown(rows: list[PairScore]) -> str:
+        counts: dict[str, int] = {}
+        for row in rows:
+            counts[row.pair.batch] = counts.get(row.pair.batch, 0) + 1
+        return " + ".join(f"{count} batch {batch}" for batch, count in sorted(counts.items()))
+
     print(
-        f"\nLabeled pairs: {len(positives)} true-dupe "
-        f"({sum(1 for s in positives if s.pair.batch == 'A')} batch A + "
-        f"{sum(1 for s in positives if s.pair.batch == 'B')} batch B), "
-        f"{len(negatives)} non-dupe "
-        f"({sum(1 for s in negatives if s.pair.batch == 'A')} batch A + "
-        f"{sum(1 for s in negatives if s.pair.batch == 'B')} batch B)"
+        f"\nLabeled pairs: {len(positives)} true-dupe ({_batch_breakdown(positives)}), "
+        f"{len(negatives)} non-dupe ({_batch_breakdown(negatives)})"
     )
     _stats(f"OLD (first-20k jaccard >= {_OLD_THRESHOLD})", lambda s: s.old_jaccard >= _OLD_THRESHOLD)
     _stats(


### PR DESCRIPTION
## Summary
- Persist the 12 pairs from the 2026-08-05 strong/moderate-similarity review (all document-audited as genuinely different deals) as a committed fixture, `etl/src/etl/utils/dedupe_labeled_negatives_20260805.json`, and load them into `eval_dedupe_similarity.py` as batch D negatives. Includes the Wood Sage pair (jaccard ~0.97, same drafter template, different transactions) — the hardest known negative.
- Teach the eval about the `dedupe_plan_20260805c` run that happened since it was written: search its backup tables (`dedupe_bak_20260805c_pages`/`_agreements`) for removed-loser text, count its one confirmed-dupe pair as a batch C positive, and let its label override the batch A tier-0 pair it re-adjudicated (without this the eval crashes on the missing loser text).
- Skip the one fixture pair (3652de8d/acd2c7b6) already labeled as a batch A tier-0 negative, so nothing is double-counted.

## Eval result
187 positives / 28 negatives (4 A + 13 B + 11 D).
- **Zero AUTO_DEDUPE decisions on all 28 negatives** (requirement holds); every batch D pair routes to `review:party_metadata_conflict` or `review:dated_as_of_mismatch`.
- Auto-dedupe recall on positives 0.898 (168/187) at precision 1.000; guard visibility (auto or review) 1.000.

## Testing
- `python -m unittest` on `test_dedupe_signatures`, `test_corpus_dedupe_guard`, `test_a_staging_dedup`: 65 tests, all pass.
- `basedpyright src/etl/utils/eval_dedupe_similarity.py`: 0 errors (5 pre-existing implicit-string-concat warnings, unchanged from main).
- Full eval run against local DB completes cleanly.