### PR TITLE
Default the taxonomy page to tree view and add copy/download export

### DIFF
--- a/frontend/client/components/TaxonomyExportButtons.spec.tsx
+++ b/frontend/client/components/TaxonomyExportButtons.spec.tsx
@@ -14,6 +14,9 @@ const TREE_TEXT = "Corporate [L1-CORP] (1 groups, 0 types)\n└── Group [L2-
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  // Must run even when a test fails mid-body, or the replaced global URL
+  // leaks into the next test and fails it for the wrong reason.
+  vi.unstubAllGlobals();
 });
 
 function setClipboard(writeText: (value: string) => Promise<void>) {
@@ -101,7 +104,10 @@ describe("TaxonomyExportButtons", () => {
     expect(blob.type).toBe("text/plain;charset=utf-8;");
     await expect(blob.text()).resolves.toBe(TREE_TEXT);
 
-    vi.unstubAllGlobals();
+    // The object URL is released once the click has been handled.
+    await waitFor(() =>
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:taxonomy"),
+    );
   });
 
   it("disables both controls when there is nothing to export", () => {

--- a/frontend/client/components/TaxonomyExportButtons.spec.tsx
+++ b/frontend/client/components/TaxonomyExportButtons.spec.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+/**
+ * Behavioral contract for the taxonomy copy/download controls: the clipboard
+ * receives the tree text, the download produces a .txt blob under the given
+ * file name, and both are inert while there is nothing to export.
+ */
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TaxonomyExportButtons } from "./TaxonomyExportButtons";
+
+const TREE_TEXT = "Corporate [L1-CORP] (1 groups, 0 types)\n└── Group [L2-A] (0 types)";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function setClipboard(writeText: (value: string) => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe("TaxonomyExportButtons", () => {
+  beforeEach(() => {
+    setClipboard(vi.fn().mockResolvedValue(undefined));
+  });
+
+  it("writes the tree text to the clipboard and confirms the copy", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard(writeText);
+
+    render(
+      <TaxonomyExportButtons
+        getText={() => TREE_TEXT}
+        fileName="taxonomy_2026-08-06.txt"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copy taxonomy tree/i }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(TREE_TEXT));
+    await screen.findByText("Copied");
+    expect(screen.getByRole("status").textContent).toBe(
+      "Taxonomy tree copied to clipboard",
+    );
+  });
+
+  it("surfaces a failed clipboard write instead of claiming success", async () => {
+    setClipboard(vi.fn().mockRejectedValue(new Error("denied")));
+
+    render(
+      <TaxonomyExportButtons
+        getText={() => TREE_TEXT}
+        fileName="taxonomy_2026-08-06.txt"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copy taxonomy tree/i }));
+
+    await screen.findByText("Copy failed");
+    expect(screen.queryByText("Copied")).toBeNull();
+  });
+
+  it("downloads a text/plain blob named after the taxonomy", async () => {
+    const createObjectURL = vi.fn().mockReturnValue("blob:taxonomy");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+
+    const clicked: HTMLAnchorElement[] = [];
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        clicked.push(this);
+      });
+
+    render(
+      <TaxonomyExportButtons
+        getText={() => TREE_TEXT}
+        fileName="taxonomy_2026-08-06.txt"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /download taxonomy tree/i }),
+    );
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(clicked[0].download).toBe("taxonomy_2026-08-06.txt");
+    expect(clicked[0].getAttribute("href")).toBe("blob:taxonomy");
+    expect(clicked[0].isConnected).toBe(false);
+
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("text/plain;charset=utf-8;");
+    await expect(blob.text()).resolves.toBe(TREE_TEXT);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("disables both controls when there is nothing to export", () => {
+    const getText = vi.fn().mockReturnValue("");
+    render(
+      <TaxonomyExportButtons
+        getText={getText}
+        fileName="taxonomy_2026-08-06.txt"
+        disabled
+      />,
+    );
+
+    for (const name of [/copy taxonomy tree/i, /download taxonomy tree/i]) {
+      const button = screen.getByRole("button", { name }) as HTMLButtonElement;
+      expect(button.disabled).toBe(true);
+      fireEvent.click(button);
+    }
+    expect(getText).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/client/components/TaxonomyExportButtons.tsx
+++ b/frontend/client/components/TaxonomyExportButtons.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, Copy, Download } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { logger } from "@/lib/logger";
+
+type CopyState = "idle" | "copied" | "failed";
+
+export interface TaxonomyExportButtonsProps {
+  /** Built lazily so the tree text is only rendered when a button is used. */
+  getText: () => string;
+  fileName: string;
+  disabled?: boolean;
+}
+
+/**
+ * Copy-to-clipboard and download-as-.txt controls for the taxonomy tree.
+ * Both emit the same tree-shaped plain text regardless of the view mode
+ * currently selected on the page.
+ */
+export function TaxonomyExportButtons({
+  getText,
+  fileName,
+  disabled = false,
+}: TaxonomyExportButtonsProps) {
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const resetTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
+
+  const flashCopyState = (state: CopyState) => {
+    setCopyState(state);
+    if (resetTimerRef.current) {
+      window.clearTimeout(resetTimerRef.current);
+    }
+    resetTimerRef.current = window.setTimeout(() => {
+      setCopyState("idle");
+      resetTimerRef.current = null;
+    }, 2000);
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(getText());
+      flashCopyState("copied");
+    } catch {
+      logger.warn("Taxonomy clipboard write failed.");
+      flashCopyState("failed");
+    }
+  };
+
+  const handleDownload = () => {
+    const blob = new Blob([getText()], { type: "text/plain;charset=utf-8;" });
+    const objectUrl = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = objectUrl;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+  };
+
+  const copyLabel =
+    copyState === "copied"
+      ? "Copied"
+      : copyState === "failed"
+        ? "Copy failed"
+        : "Copy";
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => void handleCopy()}
+        disabled={disabled}
+        className="h-10 px-3"
+        aria-label="Copy taxonomy tree as text"
+      >
+        {copyState === "copied" ? (
+          <Check className="h-4 w-4" aria-hidden="true" />
+        ) : (
+          <Copy className="h-4 w-4" aria-hidden="true" />
+        )}
+        {copyLabel}
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={handleDownload}
+        disabled={disabled}
+        className="h-10 px-3"
+        aria-label="Download taxonomy tree as a text file"
+      >
+        <Download className="h-4 w-4" aria-hidden="true" />
+        Download
+      </Button>
+      <span className="sr-only" role="status" aria-live="polite">
+        {copyState === "copied"
+          ? "Taxonomy tree copied to clipboard"
+          : copyState === "failed"
+            ? "Copying the taxonomy tree failed"
+            : ""}
+      </span>
+    </div>
+  );
+}

--- a/frontend/client/components/TaxonomyExportButtons.tsx
+++ b/frontend/client/components/TaxonomyExportButtons.tsx
@@ -82,7 +82,11 @@ export function TaxonomyExportButtons({
         onClick={() => void handleCopy()}
         disabled={disabled}
         className="h-10 px-3"
-        aria-label="Copy taxonomy tree as text"
+        // Folds the transient state into the name so it never contradicts the
+        // visible label (WCAG 2.5.3).
+        aria-label={
+          copyState === "idle" ? "Copy taxonomy tree as text" : copyLabel
+        }
       >
         {copyState === "copied" ? (
           <Check className="h-4 w-4" aria-hidden="true" />

--- a/frontend/client/lib/taxonomy-export.spec.ts
+++ b/frontend/client/lib/taxonomy-export.spec.ts
@@ -73,4 +73,25 @@ describe("taxonomyTextFileName", () => {
       "tax_clause_taxonomy_2026-08-06.txt",
     );
   });
+
+  // Pinned timezones on both sides of UTC: a UTC stamp would name these
+  // files after the wrong day for a third of every day.
+  it.each([
+    ["America/Los_Angeles", "2026-08-06T01:00:00Z", "taxonomy_2026-08-05.txt"],
+    ["Pacific/Auckland", "2026-08-05T22:00:00Z", "taxonomy_2026-08-06.txt"],
+  ])("stamps the local day in %s, not the UTC one", (zone, instant, expected) => {
+    const originalZone = process.env.TZ;
+    process.env.TZ = zone;
+    try {
+      expect(taxonomyTextFileName("main", new Date(instant))).toBe(expected);
+    } finally {
+      process.env.TZ = originalZone;
+    }
+  });
+
+  it("zero-pads single-digit months and days", () => {
+    expect(taxonomyTextFileName("main", new Date(2026, 0, 9))).toBe(
+      "taxonomy_2026-01-09.txt",
+    );
+  });
 });

--- a/frontend/client/lib/taxonomy-export.spec.ts
+++ b/frontend/client/lib/taxonomy-export.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatTaxonomyTreeText,
+  taxonomyTextFileName,
+} from "./taxonomy-export";
+import type { TaxonomyLevel1 } from "./taxonomy-search";
+
+const entries: TaxonomyLevel1[] = [
+  {
+    label: "Corporate",
+    id: "L1-CORP",
+    l2Count: 2,
+    l3Count: 3,
+    children: [
+      {
+        label: "Capital Structure",
+        id: "L2-CAP",
+        children: [
+          { label: "Authorized Capital", id: "L3-AUTH" },
+          { label: "Outstanding Shares", id: "L3-OUT" },
+        ],
+      },
+      {
+        label: "Subsidiaries",
+        id: "L2-SUB",
+        children: [{ label: "Subsidiary List", id: "L3-LIST" }],
+      },
+    ],
+  },
+  {
+    label: "Tax",
+    id: "L1-TAX",
+    l2Count: 0,
+    l3Count: 0,
+    children: [],
+  },
+];
+
+describe("formatTaxonomyTreeText", () => {
+  it("renders the full three-level tree with ids and counts", () => {
+    expect(formatTaxonomyTreeText(entries)).toBe(
+      [
+        "Corporate [L1-CORP] (2 groups, 3 types)",
+        "├── Capital Structure [L2-CAP] (2 types)",
+        "│   ├── Authorized Capital [L3-AUTH]",
+        "│   └── Outstanding Shares [L3-OUT]",
+        "└── Subsidiaries [L2-SUB] (1 types)",
+        "    └── Subsidiary List [L3-LIST]",
+        "Tax [L1-TAX] (0 groups, 0 types)",
+      ].join("\n"),
+    );
+  });
+
+  it("returns an empty string when there is nothing to export", () => {
+    expect(formatTaxonomyTreeText([])).toBe("");
+  });
+
+  it("keeps the trunk connector open while more level 2 groups follow", () => {
+    const lines = formatTaxonomyTreeText(entries).split("\n");
+    // Leaves under the non-final group stay attached to the trunk...
+    expect(lines[2].startsWith("│   ")).toBe(true);
+    // ...and leaves under the final group do not.
+    expect(lines[5].startsWith("    ")).toBe(true);
+  });
+});
+
+describe("taxonomyTextFileName", () => {
+  it("names the main and tax exports distinctly and stamps the date", () => {
+    const day = new Date("2026-08-06T12:00:00Z");
+    expect(taxonomyTextFileName("main", day)).toBe("taxonomy_2026-08-06.txt");
+    expect(taxonomyTextFileName("tax", day)).toBe(
+      "tax_clause_taxonomy_2026-08-06.txt",
+    );
+  });
+});

--- a/frontend/client/lib/taxonomy-export.ts
+++ b/frontend/client/lib/taxonomy-export.ts
@@ -9,9 +9,9 @@ const line = (prefix: string, label: string, id: string, counts?: string) =>
   `${prefix}${label} [${id}]${counts ? ` (${counts})` : ""}`;
 
 /**
- * Renders the taxonomy as an indented ASCII tree — the same L1 > L2 > L3
- * shape the tree view draws, in a form that survives a paste into a plain
- * text field. Counts mirror the labels shown on screen.
+ * Renders the taxonomy as an indented box-drawing tree — the same
+ * L1 > L2 > L3 shape the tree view draws, in a form that survives a paste
+ * into a plain text field. Counts mirror the labels shown on screen.
  */
 export const formatTaxonomyTreeText = (entries: TaxonomyLevel1[]): string => {
   const lines: string[] = [];
@@ -54,12 +54,19 @@ export const formatTaxonomyTreeText = (entries: TaxonomyLevel1[]): string => {
   return lines.join("\n");
 };
 
-/** e.g. `taxonomy_2026-08-06.txt` */
+/**
+ * e.g. `taxonomy_2026-08-06.txt`. Stamped with the viewer's local date, not
+ * the UTC one — a download at 6pm in Los Angeles belongs to that day, not to
+ * tomorrow.
+ */
 export const taxonomyTextFileName = (
   kind: "main" | "tax",
   today: Date = new Date(),
 ) => {
-  const stamp = today.toISOString().split("T")[0];
+  const pad = (value: number) => String(value).padStart(2, "0");
+  const stamp = `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(
+    today.getDate(),
+  )}`;
   const base = kind === "tax" ? "tax_clause_taxonomy" : "taxonomy";
   return `${base}_${stamp}.txt`;
 };

--- a/frontend/client/lib/taxonomy-export.ts
+++ b/frontend/client/lib/taxonomy-export.ts
@@ -1,0 +1,65 @@
+import type { TaxonomyLevel1 } from "@/lib/taxonomy-search";
+
+const BRANCH = "├── ";
+const LAST_BRANCH = "└── ";
+const TRUNK = "│   ";
+const GAP = "    ";
+
+const line = (prefix: string, label: string, id: string, counts?: string) =>
+  `${prefix}${label} [${id}]${counts ? ` (${counts})` : ""}`;
+
+/**
+ * Renders the taxonomy as an indented ASCII tree — the same L1 > L2 > L3
+ * shape the tree view draws, in a form that survives a paste into a plain
+ * text field. Counts mirror the labels shown on screen.
+ */
+export const formatTaxonomyTreeText = (entries: TaxonomyLevel1[]): string => {
+  const lines: string[] = [];
+
+  entries.forEach((entry) => {
+    lines.push(
+      line(
+        "",
+        entry.label,
+        entry.id,
+        `${entry.l2Count} groups, ${entry.l3Count} types`,
+      ),
+    );
+
+    entry.children.forEach((child, childIndex) => {
+      const isLastChild = childIndex === entry.children.length - 1;
+      lines.push(
+        line(
+          isLastChild ? LAST_BRANCH : BRANCH,
+          child.label,
+          child.id,
+          `${child.children.length} types`,
+        ),
+      );
+
+      const leafTrunk = isLastChild ? GAP : TRUNK;
+      child.children.forEach((leaf, leafIndex) => {
+        const isLastLeaf = leafIndex === child.children.length - 1;
+        lines.push(
+          line(
+            `${leafTrunk}${isLastLeaf ? LAST_BRANCH : BRANCH}`,
+            leaf.label,
+            leaf.id,
+          ),
+        );
+      });
+    });
+  });
+
+  return lines.join("\n");
+};
+
+/** e.g. `taxonomy_2026-08-06.txt` */
+export const taxonomyTextFileName = (
+  kind: "main" | "tax",
+  today: Date = new Date(),
+) => {
+  const stamp = today.toISOString().split("T")[0];
+  const base = kind === "tax" ? "tax_clause_taxonomy" : "taxonomy";
+  return `${base}_${stamp}.txt`;
+};

--- a/frontend/client/pages/Taxonomy.spec.tsx
+++ b/frontend/client/pages/Taxonomy.spec.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+/**
+ * Pins the taxonomy page's default view mode and the wiring of the export
+ * controls — both are single-expression decisions in the page body that no
+ * component-level test would catch if they regressed.
+ */
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { ClauseTypeTree } from "@/lib/clause-types";
+
+const useTaxonomyMock = vi.fn();
+vi.mock("@/hooks/use-taxonomy", () => ({
+  useTaxonomy: (...args: unknown[]) => useTaxonomyMock(...args),
+}));
+
+import Taxonomy from "./Taxonomy";
+
+const tree: ClauseTypeTree = {
+  Corporate: {
+    id: "L1-CORP",
+    children: {
+      "Capital Structure": {
+        id: "L2-CAP",
+        children: { "Authorized Capital": { id: "L3-AUTH" } },
+      },
+    },
+  },
+};
+
+beforeAll(() => {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+});
+
+afterEach(() => {
+  cleanup();
+  useTaxonomyMock.mockReset();
+});
+
+function renderPage(
+  state: { taxonomyTree: ClauseTypeTree | null; isLoading: boolean } = {
+    taxonomyTree: tree,
+    isLoading: false,
+  },
+) {
+  useTaxonomyMock.mockReturnValue({ ...state, error: null });
+  return render(
+    <MemoryRouter initialEntries={["/taxonomy"]}>
+      <Taxonomy />
+    </MemoryRouter>,
+  );
+}
+
+describe("Taxonomy page", () => {
+  it("opens in tree view rather than tile view", () => {
+    renderPage();
+
+    expect(
+      screen.getByRole("radio", { name: "Show tree view" }).getAttribute("data-state"),
+    ).toBe("on");
+    expect(
+      screen.getByRole("radio", { name: "Show tile view" }).getAttribute("data-state"),
+    ).toBe("off");
+    expect(screen.getByRole("heading", { name: "Taxonomy Tree View" })).toBeTruthy();
+  });
+
+  it("enables the export controls once the taxonomy has loaded", () => {
+    renderPage();
+
+    for (const name of [/copy taxonomy tree/i, /download taxonomy tree/i]) {
+      expect((screen.getByRole("button", { name }) as HTMLButtonElement).disabled).toBe(
+        false,
+      );
+    }
+  });
+
+  it("clears a pending 'Copied' flash when switching to the other taxonomy", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+      writable: true,
+    });
+
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /copy taxonomy tree/i }));
+    await screen.findByText("Copied");
+
+    // Switching tabs must not leave the previous taxonomy's success state
+    // sitting over the one now being fetched.
+    fireEvent.click(screen.getByRole("button", { name: "Tax" }));
+    await waitFor(() => expect(screen.queryByText("Copied")).toBeNull());
+  });
+
+  it("disables the export controls while the taxonomy is loading or empty", () => {
+    renderPage({ taxonomyTree: null, isLoading: true });
+
+    for (const name of [/copy taxonomy tree/i, /download taxonomy tree/i]) {
+      expect((screen.getByRole("button", { name }) as HTMLButtonElement).disabled).toBe(
+        true,
+      );
+    }
+
+    cleanup();
+    useTaxonomyMock.mockReset();
+    renderPage({ taxonomyTree: {}, isLoading: false });
+
+    for (const name of [/copy taxonomy tree/i, /download taxonomy tree/i]) {
+      expect((screen.getByRole("button", { name }) as HTMLButtonElement).disabled).toBe(
+        true,
+      );
+    }
+  });
+});

--- a/frontend/client/pages/Taxonomy.tsx
+++ b/frontend/client/pages/Taxonomy.tsx
@@ -31,6 +31,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { TaxonomyExportButtons } from "@/components/TaxonomyExportButtons";
+import {
+  formatTaxonomyTreeText,
+  taxonomyTextFileName,
+} from "@/lib/taxonomy-export";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { scheduleWhenBrowserIdle } from "@/lib/analytics";
 import { logger } from "@/lib/logger";
@@ -100,7 +105,7 @@ export default function Taxonomy() {
   const [openLevel2ByParent, setOpenLevel2ByParent] = useState<
     Record<string, string[]>
   >({});
-  const [viewMode, setViewMode] = useState<TaxonomyViewMode>("tile");
+  const [viewMode, setViewMode] = useState<TaxonomyViewMode>("tree");
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const [shouldRenderTree, setShouldRenderTree] = useState(false);
   const highlightTimerRef = useRef<number | null>(null);
@@ -643,34 +648,41 @@ export default function Taxonomy() {
             >
               {viewMode === "tree" ? `${treeTitle} View` : treeTitle}
             </h2>
-            <div className="flex items-center gap-3 sm:justify-end">
-              <Label
-                htmlFor="taxonomy-view-mode-tile"
-                className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-              >
-                View
-              </Label>
-              <ToggleGroup
-                type="single"
-                value={viewMode}
-                onValueChange={(value) => {
-                  if (value === "tile" || value === "tree") {
-                    setViewMode(value);
-                  }
-                }}
-                aria-label="Taxonomy view"
-              >
-                <ToggleGroupItem
-                  id="taxonomy-view-mode-tile"
-                  value="tile"
-                  aria-label="Show tile view"
+            <div className="flex flex-wrap items-center gap-3 sm:justify-end">
+              <TaxonomyExportButtons
+                getText={() => formatTaxonomyTreeText(taxonomyEntries)}
+                fileName={taxonomyTextFileName(currentTab)}
+                disabled={isLoading || taxonomyEntries.length === 0}
+              />
+              <div className="flex items-center gap-3">
+                <Label
+                  htmlFor="taxonomy-view-mode-tile"
+                  className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
                 >
-                  Tile
-                </ToggleGroupItem>
-                <ToggleGroupItem value="tree" aria-label="Show tree view">
-                  Tree
-                </ToggleGroupItem>
-              </ToggleGroup>
+                  View
+                </Label>
+                <ToggleGroup
+                  type="single"
+                  value={viewMode}
+                  onValueChange={(value) => {
+                    if (value === "tile" || value === "tree") {
+                      setViewMode(value);
+                    }
+                  }}
+                  aria-label="Taxonomy view"
+                >
+                  <ToggleGroupItem
+                    id="taxonomy-view-mode-tile"
+                    value="tile"
+                    aria-label="Show tile view"
+                  >
+                    Tile
+                  </ToggleGroupItem>
+                  <ToggleGroupItem value="tree" aria-label="Show tree view">
+                    Tree
+                  </ToggleGroupItem>
+                </ToggleGroup>
+              </div>
             </div>
           </div>
 

--- a/frontend/client/pages/Taxonomy.tsx
+++ b/frontend/client/pages/Taxonomy.tsx
@@ -650,6 +650,10 @@ export default function Taxonomy() {
             </h2>
             <div className="flex flex-wrap items-center gap-3 sm:justify-end">
               <TaxonomyExportButtons
+                // Remount on tab change so a "Copied" flash from the previous
+                // taxonomy can't linger over the one now loading, matching how
+                // handleTabChange clears the page's other transient state.
+                key={currentTab}
                 getText={() => formatTaxonomyTreeText(taxonomyEntries)}
                 fileName={taxonomyTextFileName(currentTab)}
                 disabled={isLoading || taxonomyEntries.length === 0}


### PR DESCRIPTION
## What

- **Tree is the default view.** The taxonomy page previously opened in tile view; it now opens in tree view.
- **Copy and Download buttons**, placed to the left of the Tile/Tree toggle.
  - Copy writes the tree to the clipboard as plain text.
  - Download saves a `.txt` named for the active taxonomy and date (`taxonomy_2026-08-06.txt`, `tax_clause_taxonomy_2026-08-06.txt`).
  - Both emit the same ASCII tree regardless of the selected view, so the export is stable from tile view too.

Export format:

```
Corporate Organization [L1-CORP] (2 groups, 4 types)
├── Capital Structure [L2-CAP] (3 types)
│   ├── Authorized Capital [L3-AUTH]
│   └── Voting Agreements [L3-VOTE]
└── Subsidiaries [L2-SUB] (1 types)
    └── Subsidiary List [L3-LIST]
```

Counts mirror the labels already shown on the page.

## Notes

- The tree text is built lazily on click, not on every render.
- A rejected `clipboard.writeText` surfaces "Copy failed" rather than claiming success.
- Both controls are disabled while the taxonomy is loading or empty.
- The View label and Tile/Tree toggle are now grouped so they wrap as a unit on narrow screens instead of the label orphaning.

## Verification

- 8 new tests (`taxonomy-export.spec.ts`, `TaxonomyExportButtons.spec.tsx`); full frontend suite 172 passed, `tsc` clean, `eslint` reports no new warnings.
- Live browser run against the dev server (stub taxonomy API, since the backend isn't runnable in the worktree): tree is the default on load; a real click on Copy resolved `clipboard.writeText` with the correct tree text and rendered the "Copied" state; real clicks on Download produced actual files on disk from both the Main and Tax tabs with the expected contents. Tile toggle still works, no console errors, no horizontal overflow at 375px.