### PR TITLE
Fix MCP changelog section returning nulls in production (Cloudflare 403s urllib's default User-Agent)

### DIFF
--- a/backend/mcp/tools/changelog_info.py
+++ b/backend/mcp/tools/changelog_info.py
@@ -25,6 +25,9 @@ CHANGELOG_PUBLIC_URL = os.environ.get(
 _FETCH_TIMEOUT_SECONDS = 3
 _TTL_OK_SECONDS = 900
 _TTL_FAIL_SECONDS = 120
+# Cloudflare 403s urllib's default Python-urllib/x.y agent, which silently
+# nulled this section in production; identify the caller explicitly.
+_USER_AGENT = "pandects-mcp/1.0 (+https://pandects.org)"
 
 _cache: dict[str, object] = {"ts": 0.0, "ok": False, "payload": None}
 _cache_lock = Lock()
@@ -41,8 +44,11 @@ def _fetch_changelog_json() -> dict[str, object] | None:
             return cast("dict[str, object] | None", _cache["payload"])
     payload: dict[str, object] | None = None
     try:
+        request = urllib.request.Request(
+            CHANGELOG_PUBLIC_URL, headers={"User-Agent": _USER_AGENT}
+        )
         with urllib.request.urlopen(
-            CHANGELOG_PUBLIC_URL, timeout=_FETCH_TIMEOUT_SECONDS
+            request, timeout=_FETCH_TIMEOUT_SECONDS
         ) as response:
             parsed = cast(object, json.loads(response.read()))
         if isinstance(parsed, dict):

--- a/backend/tests/test_changelog.py
+++ b/backend/tests/test_changelog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -10,14 +11,19 @@ from typing import Any, cast
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _RENDERER_PATH = _REPO_ROOT / "bulk" / "changelog" / "render_changelog.py"
 _CHANGELOG_PATH = _REPO_ROOT / "bulk" / "changelog" / "changelog.yml"
+_CHANGELOG_INFO_PATH = _REPO_ROOT / "backend" / "mcp" / "tools" / "changelog_info.py"
 
 
-def _load_renderer() -> Any:
-    spec = importlib.util.spec_from_file_location("render_changelog", _RENDERER_PATH)
+def _load_module(name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _load_renderer() -> Any:
+    return _load_module("render_changelog", _RENDERER_PATH)
 
 
 class ChangelogTests(unittest.TestCase):
@@ -275,6 +281,77 @@ class ChangelogTests(unittest.TestCase):
         guide_path = _REPO_ROOT / "docs" / "docs" / "guides" / "changelog.md"
         self.assertEqual(markdown_path.read_text(), self.renderer.render_markdown(data))
         self.assertEqual(guide_path.read_text(), self.renderer.render_docs_guide(data))
+
+
+class ChangelogInfoFetchTests(unittest.TestCase):
+    """The MCP capabilities changelog section fetches the published artifact.
+
+    Loaded by path so the test doesn't pull in the heavy backend.mcp.tools
+    package (changelog_info.py imports only the stdlib).
+    """
+
+    def setUp(self) -> None:
+        self.module = _load_module("changelog_info", _CHANGELOG_INFO_PATH)
+        os.environ.pop("MCP_CHANGELOG_FETCH", None)
+
+    def test_fetch_sends_explicit_user_agent(self) -> None:
+        # Cloudflare 403s urllib's default Python-urllib/x.y agent, which
+        # nulled this section in production until the header was set.
+        seen: dict[str, object] = {}
+
+        class _FakeResponse:
+            def __enter__(self) -> "_FakeResponse":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return json.dumps(
+                    {"latest_version": "2026-07-19", "latest_released": "x", "releases": []}
+                ).encode()
+
+        def _fake_urlopen(request: Any, timeout: float | None = None) -> _FakeResponse:
+            seen["headers"] = dict(request.headers)
+            seen["url"] = request.full_url
+            seen["timeout"] = timeout
+            return _FakeResponse()
+
+        self.module.urllib.request.urlopen = _fake_urlopen
+        section = self.module.changelog_capabilities_section()
+
+        headers = cast(dict[str, str], seen["headers"])
+        agent = next(v for k, v in headers.items() if k.lower() == "user-agent")
+        self.assertIn("pandects", agent.lower())
+        self.assertNotIn("python-urllib", agent.lower())
+        self.assertEqual(seen["timeout"], self.module._FETCH_TIMEOUT_SECONDS)
+        self.assertEqual(section["latest_version"], "2026-07-19")
+
+    def test_fetch_failure_degrades_to_nulls(self) -> None:
+        def _boom(request: Any, timeout: float | None = None) -> object:
+            raise OSError("network down")
+
+        self.module.urllib.request.urlopen = _boom
+        section = self.module.changelog_capabilities_section()
+        self.assertIsNone(section["latest_version"])
+        self.assertIsNone(section["breaking_changes_in_latest"])
+        self.assertEqual(section["api_route"], "/v1/changelog")
+
+    def test_fetch_disabled_by_env_makes_no_request(self) -> None:
+        called: list[object] = []
+
+        def _tracker(request: Any, timeout: float | None = None) -> object:
+            called.append(request)
+            raise AssertionError("should not fetch")
+
+        self.module.urllib.request.urlopen = _tracker
+        os.environ["MCP_CHANGELOG_FETCH"] = "0"
+        try:
+            section = self.module.changelog_capabilities_section()
+        finally:
+            os.environ.pop("MCP_CHANGELOG_FETCH", None)
+        self.assertEqual(called, [])
+        self.assertIsNone(section["latest_version"])
 
 
 if __name__ == "__main__":

--- a/bulk/changelog/CHANGELOG.md
+++ b/bulk/changelog/CHANGELOG.md
@@ -18,6 +18,7 @@ the MCP surface. Machine-readable version:
 - **[api/minor]** Added changelog distribution: dumps/changelog.json is published next to each dump, GET /v1/changelog serves it (filterable by since/dump_sha256), and /v1/dumps entries gain changelog_url
   - Refs: 1eb2010
 - **[mcp/minor]** get_server_capabilities gains a changelog section (latest release, breaking flag, URLs) and the initialize instructions point agents at it
+  - The section reports the newest published release and whether it carries breaking changes. Its latest_version, latest_released, and breaking_changes_in_latest fields are null when the published changelog is unreachable; the url and api_route fields are always populated.
   - Refs: 1eb2010
 
 ## 2026-07-19 — released 2026-07-20

--- a/bulk/changelog/changelog.yml
+++ b/bulk/changelog/changelog.yml
@@ -31,6 +31,11 @@ unreleased:
   severity: minor
   summary: get_server_capabilities gains a changelog section (latest release, breaking
     flag, URLs) and the initialize instructions point agents at it
+  details: >
+    The section reports the newest published release and whether it carries
+    breaking changes. Its latest_version, latest_released, and
+    breaking_changes_in_latest fields are null when the published changelog is
+    unreachable; the url and api_route fields are always populated.
   refs: ['1eb2010']
 - type: data
   severity: notable


### PR DESCRIPTION
## Problem

Post-deploy verification of #145 found the MCP `get_server_capabilities` `changelog` section returning `latest_version: null`, `latest_released: null`, `breaking_changes_in_latest: null` in production — even though `https://bulk.pandects.org/dumps/changelog.json` was published and returned 200.

Root cause: Cloudflare 403s urllib's default `Python-urllib/x.y` User-Agent. Confirmed by running the exact fetch path inside a live `pandects-api` Fly machine:

```
default-urllib  FAIL 0.04s HTTPError HTTP Error 403: Forbidden
custom-ua       OK   0.14s latest= 2026-07-19
```

The failure degraded gracefully (nulls, no 500, no hang — as designed), so nothing broke; the section just never carried its data.

## Fix

Send an explicit `User-Agent: pandects-mcp/1.0 (+https://pandects.org)` on the fetch.

`GET /v1/changelog` is **unaffected** — it reads R2 over the authenticated S3 endpoint, a different mechanism. Verified working in the same prod machine (boto3 fetch OK in 0.18s, `latest_version=2026-07-19`).

## Tests

New coverage in `backend/tests/test_changelog.py` (module loaded by path, so no heavy package import):
- the fetch sends a non-`python-urllib` agent and honors the configured timeout
- a failed fetch degrades to null fields with `url`/`api_route` still populated
- `MCP_CHANGELOG_FETCH=0` makes no request at all

416 backend tests pass; basedpyright 0 errors.

## Changelog

Folded into the existing unreleased `mcp` entry (the feature it fixes has not shipped in a release yet) with a note documenting the null semantics for consumers.