### PR TITLE
Update the access-lockdown notice from July to September

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -915,18 +915,18 @@ def _current_access_context() -> AccessContext:
     return AccessContext(tier="anonymous")
 
 
-# --- Temporary July access restrictions -------------------------------------
+# --- Temporary September access restrictions ---------------------------------
 # New account creation is disabled and the data API is limited to accounts that
 # already existed before the current day, surfaced in-app as a "check back in
-# July" notice. To reopen access, remove _temporary_access_gate (and its
+# September" notice. To reopen access, remove _temporary_access_gate (and its
 # before_request registration in _register_request_hooks) plus the OAuth
 # register guard in backend/routes/auth/__init__.py.
 _REGISTRATION_DISABLED_MESSAGE = (
-    "New user creation is temporarily disabled. Please check back in July."
+    "New user creation is temporarily disabled. Please check back in September."
 )
 _DATA_API_DISABLED_MESSAGE = (
     "This API is temporarily disabled for non-authenticated users. "
-    "Please check back in July."
+    "Please check back in September."
 )
 
 
@@ -1414,7 +1414,7 @@ def _register_request_hooks(target_app: Flask) -> None:
         populate_dump_version=_populate_dump_version,
         attach_dump_version_header=_attach_dump_version_header,
     )
-    # Temporary July gate; registered after the core guard so g.access_ctx is set.
+    # Temporary September gate; registered after the core guard so g.access_ctx is set.
     _temp_access_gate: object = target_app.before_request(_temporary_access_gate)
 
 # Legacy helper names kept so route dependency wiring and tests can import one app module.

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -152,7 +152,7 @@ def max_content_length() -> int:
 
 
 def temporary_access_lockdown_enabled() -> bool:
-    """TEMPORARY (July reopen): when enabled, new account creation is blocked and
+    """TEMPORARY (September reopen): when enabled, new account creation is blocked and
     the data API is limited to accounts created before the current day. Enabled by
     default so production deploys pick it up without extra config; set
     TEMPORARY_ACCESS_LOCKDOWN=0 to disable (the test suite does this to exercise

--- a/backend/routes/auth/__init__.py
+++ b/backend/routes/auth/__init__.py
@@ -305,13 +305,13 @@ def register_auth_routes(app: Flask, *, deps: AuthDeps) -> Blueprint:
     ):
         action, user = _resolve_user_from_external_identity(external_identity=external_identity)
         if action == "register" and temporary_access_lockdown_enabled():
-            # TEMPORARY (July reopen): new account creation is disabled, so
+            # TEMPORARY (September reopen): new account creation is disabled, so
             # discard the just-created user/link instead of provisioning it.
             deps.db.session.rollback()
             abort(
                 403,
                 description=(
-                    "New user creation is temporarily disabled. Please check back in July."
+                    "New user creation is temporarily disabled. Please check back in September."
                 ),
             )
         claims = getattr(external_identity, "claims", None)

--- a/frontend/client/components/AccessGate.tsx
+++ b/frontend/client/components/AccessGate.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { useAuth } from "@/hooks/use-auth";
 import { LockdownNotice } from "@/components/LockdownNotice";
 
-// TEMPORARY (July reopen): renders the wrapped data page only for signed-in
+// TEMPORARY (September reopen): renders the wrapped data page only for signed-in
 // (existing) accounts; everyone else gets the lockdown notice instead of the
 // API errors a locked-down page would otherwise show. While auth is still
 // resolving we render nothing so the page never fires its (403-bound) requests.

--- a/frontend/client/components/LockdownNotice.tsx
+++ b/frontend/client/components/LockdownNotice.tsx
@@ -4,7 +4,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
-// TEMPORARY (July reopen): rendered in place of data-driven pages while the API
+// TEMPORARY (September reopen): rendered in place of data-driven pages while the API
 // is locked down to existing accounts. See lib/lockdown.ts for the gated paths.
 export function LockdownNotice() {
   const location = useLocation();
@@ -16,7 +16,7 @@ export function LockdownNotice() {
           <AlertTitle>This page is temporarily unavailable</AlertTitle>
           <AlertDescription>
             Access is temporarily limited to existing accounts, and new user creation is
-            paused. Please check back in July.
+            paused. Please check back in September.
           </AlertDescription>
         </Alert>
         <div className="mt-6 text-center text-sm text-muted-foreground">

--- a/frontend/client/lib/lockdown.ts
+++ b/frontend/client/lib/lockdown.ts
@@ -1,4 +1,4 @@
-// TEMPORARY (July reopen): paths whose pages hydrate via the locked-down data
+// TEMPORARY (September reopen): paths whose pages hydrate via the locked-down data
 // API. <AccessGate> swaps these for the lockdown notice for visitors who aren't
 // signed in, so they get a clean message instead of API error states. To reopen
 // public access, empty this set (and remove the AccessGate wiring in main.tsx

--- a/frontend/client/pages/Login.tsx
+++ b/frontend/client/pages/Login.tsx
@@ -397,9 +397,9 @@ export default function Login() {
                 </div>
               </form>
 
-              {/* TEMPORARY (July reopen): new account creation is disabled. */}
+              {/* TEMPORARY (September reopen): new account creation is disabled. */}
               <div className="text-center text-sm text-muted-foreground">
-                New account creation is temporarily disabled. Please check back in July.
+                New account creation is temporarily disabled. Please check back in September.
               </div>
             </div>
           </Card>

--- a/frontend/client/pages/Signup.tsx
+++ b/frontend/client/pages/Signup.tsx
@@ -6,7 +6,7 @@ import { Card } from "@/components/ui/card";
 import { useAuth } from "@/hooks/use-auth";
 import { nextPathRequiresDocumentNavigation, safeNextPath } from "@/lib/auth-next";
 
-// TEMPORARY (July reopen): new account creation is disabled. Restore the prior
+// TEMPORARY (September reopen): new account creation is disabled. Restore the prior
 // signup form (Google + email/password + captcha + legal/verify flow) from
 // version control to re-enable registration.
 export default function Signup() {
@@ -27,7 +27,7 @@ export default function Signup() {
         <Alert>
           <AlertTitle>Account creation is temporarily disabled</AlertTitle>
           <AlertDescription>
-            New user creation is temporarily disabled. Please check back in July.
+            New user creation is temporarily disabled. Please check back in September.
           </AlertDescription>
         </Alert>
         <div className="mt-6 text-center text-sm text-muted-foreground">


### PR DESCRIPTION
The lockdown copy still told visitors to "check back in July", which is now past.

## Changed (8 files)

**User-facing copy** — 4 distinct strings:
- `frontend/client/components/LockdownNotice.tsx` — the gated-page notice
- `frontend/client/pages/Login.tsx` — new-account-creation note
- `frontend/client/pages/Signup.tsx` — signup disabled note
- `backend/app.py` — `_REGISTRATION_DISABLED_MESSAGE` and `_DATA_API_DISABLED_MESSAGE`
- `backend/routes/auth/__init__.py` — the OAuth register-guard abort description

**Paired code markers**, so comments don't contradict the copy: the `TEMPORARY (July reopen)` markers in `AccessGate.tsx`, `lockdown.ts`, `LockdownNotice.tsx`, `Login.tsx`, `Signup.tsx`, `backend/core/config.py`, `backend/routes/auth/__init__.py`, and the section banner / gate comment in `backend/app.py`.

## Deliberately NOT changed

- `etl/src/etl/domain/dedupe_signatures.py` — `"july": 7` is a month-name→number parsing table. Rewriting it would break date parsing.
- `frontend/DESIGN_REVIEW.md` — "post UI-polish pass, July 2026" is a historical record of when that work happened.

After this change, those two are the only `July` occurrences left in the repo.

## Verification

- Backend: 416 tests pass (including `test_temporary_access_gate`, which asserts on the "temporarily disabled" prefix rather than the month, so it was never month-coupled); basedpyright 0 errors
- Frontend: 179 tests pass, typecheck clean, lint 0 errors
- Restored the `backend/app.py` comment banner to its original 79-char width after the longer word