### PR TITLE
Make the taxonomy export filename test independent of ambient TZ

### DIFF
--- a/frontend/client/lib/taxonomy-export.spec.ts
+++ b/frontend/client/lib/taxonomy-export.spec.ts
@@ -66,10 +66,14 @@ describe("formatTaxonomyTreeText", () => {
 });
 
 describe("taxonomyTextFileName", () => {
+  // Every case pins an explicit zone rather than the ambient one, so the
+  // assertions hold whatever TZ the machine or CI runner happens to use.
   it("names the main and tax exports distinctly and stamps the date", () => {
     const day = new Date("2026-08-06T12:00:00Z");
-    expect(taxonomyTextFileName("main", day)).toBe("taxonomy_2026-08-06.txt");
-    expect(taxonomyTextFileName("tax", day)).toBe(
+    expect(taxonomyTextFileName("main", day, "UTC")).toBe(
+      "taxonomy_2026-08-06.txt",
+    );
+    expect(taxonomyTextFileName("tax", day, "UTC")).toBe(
       "tax_clause_taxonomy_2026-08-06.txt",
     );
   });
@@ -80,18 +84,24 @@ describe("taxonomyTextFileName", () => {
     ["America/Los_Angeles", "2026-08-06T01:00:00Z", "taxonomy_2026-08-05.txt"],
     ["Pacific/Auckland", "2026-08-05T22:00:00Z", "taxonomy_2026-08-06.txt"],
   ])("stamps the local day in %s, not the UTC one", (zone, instant, expected) => {
-    const originalZone = process.env.TZ;
-    process.env.TZ = zone;
-    try {
-      expect(taxonomyTextFileName("main", new Date(instant))).toBe(expected);
-    } finally {
-      process.env.TZ = originalZone;
-    }
+    expect(taxonomyTextFileName("main", new Date(instant), zone)).toBe(expected);
+  });
+
+  it("defaults to the ambient zone when none is passed", () => {
+    const instant = new Date("2026-08-06T12:00:00Z");
+    const ambient = new Intl.DateTimeFormat("en-CA", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(instant);
+    expect(taxonomyTextFileName("main", instant)).toBe(
+      `taxonomy_${ambient}.txt`,
+    );
   });
 
   it("zero-pads single-digit months and days", () => {
-    expect(taxonomyTextFileName("main", new Date(2026, 0, 9))).toBe(
-      "taxonomy_2026-01-09.txt",
-    );
+    expect(
+      taxonomyTextFileName("main", new Date("2026-01-09T12:00:00Z"), "UTC"),
+    ).toBe("taxonomy_2026-01-09.txt");
   });
 });

--- a/frontend/client/lib/taxonomy-export.ts
+++ b/frontend/client/lib/taxonomy-export.ts
@@ -58,15 +58,24 @@ export const formatTaxonomyTreeText = (entries: TaxonomyLevel1[]): string => {
  * e.g. `taxonomy_2026-08-06.txt`. Stamped with the viewer's local date, not
  * the UTC one — a download at 6pm in Los Angeles belongs to that day, not to
  * tomorrow.
+ *
+ * `timeZone` defaults to the runtime zone, which is what the app wants. Tests
+ * pass it explicitly so they never have to mutate `process.env.TZ`: that
+ * assignment is a silent no-op inside a worker thread, since Node only wires
+ * the timezone-cache invalidation to the setter on the main thread.
  */
 export const taxonomyTextFileName = (
   kind: "main" | "tax",
   today: Date = new Date(),
+  timeZone?: string,
 ) => {
-  const pad = (value: number) => String(value).padStart(2, "0");
-  const stamp = `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(
-    today.getDate(),
-  )}`;
+  // en-CA formats as zero-padded YYYY-MM-DD.
+  const stamp = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(today);
   const base = kind === "tax" ? "tax_clause_taxonomy" : "taxonomy";
   return `${base}_${stamp}.txt`;
 };


### PR DESCRIPTION
## The defect

`taxonomy-export.spec.ts` pinned timezones by assigning `process.env.TZ` at runtime. That assignment is a **silent no-op inside a worker thread** — Node only wires the timezone-cache invalidation (`SetDateTimeConfigurationChangeNotification`) to the setter on the main thread, so in a worker the env map changes and V8's cached zone never does.

The suite passes today only because `frontend/` has **no vitest config at all** (no `test:` block in `vite.config.ts`, no `vitest.config.*`), so it inherits vitest 4's default `pool: 'forks'`, where the mutation lands on a child's main thread and works. It is one config line — or one upstream default change — away from permanently red.

Reproduced before the fix:

```
$ npx vitest --run --pool=threads client/lib/taxonomy-export.spec.ts
AssertionError: expected 'taxonomy_2026-08-05.txt' to be 'taxonomy_2026-08-06.txt'
```

Deterministic, 17/17. Note it fails *asymmetrically* by machine: on a box whose system zone is `America/Los_Angeles` only the Auckland case fails, because the LA case passes coincidentally. On a UTC runner **both** cases would fail.

A second, independent bug in the same block: the non-mutating test asserted that a noon-UTC instant lands on the same calendar day, which breaks above UTC+12 (`TZ=Pacific/Kiritimati` failed it).

## The fix

Pin the zone by injection instead of mutating ambient process state. `taxonomyTextFileName` takes an optional `timeZone` and formats via `Intl.DateTimeFormat("en-CA", …)`, which renders zero-padded `YYYY-MM-DD`.

Omitting the parameter preserves the existing behavior — stamping the viewer's local day — which is exactly what the one production caller (`Taxonomy.tsx:658`, `taxonomyTextFileName(currentTab)`) does. A new test covers that default path so the production behavior stays pinned.

## Verification

| scenario | before | after |
|---|---|---|
| `--pool=threads` | 17/17 fail | 8/8 pass |
| `TZ=Pacific/Kiritimati` (UTC+14) | fail | pass |
| `TZ=UTC` / `Asia/Tokyo` / `America/New_York` / `America/Los_Angeles` | pass | pass |
| full suite, default pool | 179 pass | 180 pass |
| full suite, `--pool=threads` | — | 31 files / 180 pass |

Typecheck clean, lint 0 errors.

## Behavior note (deliberate)

For an `Invalid Date`, the old arithmetic produced `taxonomy_NaN-NaN-NaN.txt`; `Intl` throws `RangeError` instead. Unreachable from the sole caller, which passes no date at all, and TypeScript requires a `Date`. Flagging it rather than adding an untested fallback branch — say the word if you'd prefer a guard.

## Out of scope (found, not fixed)

`client/lib/format-utils.spec.ts:10` has the same *class* of over-specification: it asserts `formatDateValue("2023-04-01T12:34:56Z") === "Apr 01, 2023"`, which fails at UTC+13/+14 (`expected 'Apr 02, 2023'`). Pre-existing, a different module, and invisible on GitHub's UTC runners. Left alone to keep this PR to one concern.