### PR TITLE
Pin the zone in the formatDateValue datetime test

### DIFF
--- a/frontend/client/lib/format-utils.spec.ts
+++ b/frontend/client/lib/format-utils.spec.ts
@@ -6,8 +6,17 @@ describe("formatDateValue", () => {
     expect(formatDateValue("2023-04-01")).toBe("Apr 01, 2023");
   });
 
+  // Pinned, because which calendar day an instant falls on is the viewer's
+  // local business: an unpinned expectation here fails above UTC+12.
   it("formats datetime strings", () => {
-    expect(formatDateValue("2023-04-01T12:34:56Z")).toBe("Apr 01, 2023");
+    expect(formatDateValue("2023-04-01T12:34:56Z", "UTC")).toBe("Apr 01, 2023");
+  });
+
+  it("renders a datetime in the requested zone, not the ambient one", () => {
+    // 22:00Z on the 5th is already the 6th in Auckland and still the 5th in LA.
+    const instant = "2026-08-05T22:00:00Z";
+    expect(formatDateValue(instant, "Pacific/Auckland")).toBe("Aug 06, 2026");
+    expect(formatDateValue(instant, "America/Los_Angeles")).toBe("Aug 05, 2026");
   });
 
   it("returns an em dash for invalid values", () => {

--- a/frontend/client/lib/format-utils.ts
+++ b/frontend/client/lib/format-utils.ts
@@ -36,13 +36,19 @@ export function formatDate(value: string | null): string {
 /**
  * Formats a date string to a short date format (e.g., "Jan 15, 2024")
  * @param value - Date string or null
+ * @param timeZone - Zone to render in; defaults to the viewer's. Tests pass it
+ *   so a datetime input renders the same day regardless of the runner's zone.
  * @returns Formatted date string or "—" if invalid/null
  */
-export function formatDateValue(value?: string | null): string {
+export function formatDateValue(
+  value?: string | null,
+  timeZone?: string,
+): string {
   if (!value) return "—";
   const dt = parseDateValue(value);
   if (!dt) return "—";
   return new Intl.DateTimeFormat("en-US", {
+    timeZone,
     year: "numeric",
     month: "short",
     day: "2-digit",


### PR DESCRIPTION
Last instance of the over-specification found during the taxonomy export investigation.

## The defect

`format-utils.spec.ts` asserted that a noon-UTC instant renders as a fixed calendar day:

```js
expect(formatDateValue("2023-04-01T12:34:56Z")).toBe("Apr 01, 2023");
```

That only holds below UTC+12. At `TZ=Pacific/Kiritimati` it rendered `Apr 02, 2023` and failed. Pre-existing, and invisible on GitHub's UTC runners.

## The fix

`formatDateValue` takes an optional `timeZone`, mirroring `taxonomyTextFileName` from #152; the datetime test pins `UTC`. All 23 existing call sites pass a single argument and are unaffected — production still renders in the viewer's zone.

Added a case asserting the zone argument actually drives the output (the same instant renders as the 6th in Auckland and the 5th in Los Angeles), so the parameter is covered rather than merely accepted.

**The date-only test deliberately stays ambient.** `parseDateValue` builds a *local* date for `YYYY-MM-DD` inputs on purpose; pinning UTC there would make it render the previous day for zones ahead of UTC — exactly the drift that test exists to prevent.

## Verification

| | before | after |
|---|---|---|
| `format-utils.spec.ts` at UTC+14 | 1 failed | 4 passed |
| same, at UTC / Auckland / LA / Tokyo | pass | pass |
| same, `--pool=threads` | — | pass |
| **full suite** at UTC+14 | **1 failed / 179** | **181 passed** |
| full suite at UTC / LA / Tokyo | pass | 181 passed |

Typecheck clean, lint 0 errors. The suite is now zone-robust in every zone tested.